### PR TITLE
Load evolution from disk

### DIFF
--- a/neurolib/optimize/evolution/evolution.py
+++ b/neurolib/optimize/evolution/evolution.py
@@ -36,7 +36,7 @@ class Evolution:
         POP_INIT_SIZE=100,
         POP_SIZE=20,
         NGEN=10,
-        algorithm='adaptive',
+        algorithm="adaptive",
         matingOperator=None,
         MATE_P=None,
         mutationOperator=None,
@@ -46,7 +46,7 @@ class Evolution:
         parentSelectionOperator=None,
         PARENT_SELECT_P=None,
         individualGenerator=None,
-        IND_GENERATOR_P=None
+        IND_GENERATOR_P=None,
     ):
         """Initialize evolutionary optimization.
         :param evalFunction: Evaluation function of a run that provides a fitness vector and simulation outputs
@@ -93,10 +93,14 @@ class Evolution:
         """
 
         if weightList is None:
-            logging.info("weightList not set, assuming single fitness value to be maximized.")
+            logging.info(
+                "weightList not set, assuming single fitness value to be maximized."
+            )
             weightList = [1.0]
 
-        trajectoryName = "results" + datetime.datetime.now().strftime("-%Y-%m-%d-%HH-%MM-%SS")
+        trajectoryName = "results" + datetime.datetime.now().strftime(
+            "-%Y-%m-%d-%HH-%MM-%SS"
+        )
         logging.info(f"Trajectory Name: {trajectoryName}")
         self.HDF_FILE = os.path.join(paths.HDF_DIR, filename)
         trajectoryFileName = self.HDF_FILE
@@ -116,7 +120,7 @@ class Evolution:
             multiproc=True,
             ncores=ncores,
             complevel=9,
-            log_config=paths.PYPET_LOGGING_CONFIG,            
+            log_config=paths.PYPET_LOGGING_CONFIG,
         )
 
         # Get the trajectory from the environment
@@ -130,7 +134,6 @@ class Evolution:
         self.model = model
         self.evalFunction = evalFunction
         self.weightList = weightList
-
 
         self.NGEN = NGEN
         assert POP_SIZE % 2 == 0, "Please chose an even number for POP_SIZE!"
@@ -161,42 +164,72 @@ class Evolution:
         self.toolbox = deap.base.Toolbox()
 
         # -------- algorithms
-        if algorithm == 'adaptive':
+        if algorithm == "adaptive":
             logging.info(f"Evolution: Using algorithm: {algorithm}")
             self.matingOperator = tools.cxBlend
-            self.MATE_P = {"alpha" : 0.5} or MATE_P
+            self.MATE_P = {"alpha": 0.5} or MATE_P
             self.mutationOperator = du.gaussianAdaptiveMutation_nStepSizes
             self.selectionOperator = du.selBest_multiObj
             self.parentSelectionOperator = du.selRank
-            self.PARENT_SELECT_P = {"s" : 1.5} or PARENT_SELECT_P
+            self.PARENT_SELECT_P = {"s": 1.5} or PARENT_SELECT_P
             self.individualGenerator = du.randomParametersAdaptive
 
-        elif algorithm == 'nsga2':
+        elif algorithm == "nsga2":
             logging.info(f"Evolution: Using algorithm: {algorithm}")
-            self.matingOperator=tools.cxSimulatedBinaryBounded
-            self.MATE_P = {"low":self.parameterSpace.lowerBound, "up":self.parameterSpace.upperBound, "eta":20.0} or MATE_P
-            self.mutationOperator=tools.mutPolynomialBounded
-            self.MUTATE_P = {"low":self.parameterSpace.lowerBound, "up":self.parameterSpace.upperBound, "eta":20.0, "indpb":1.0/len(self.weightList)} or MUTATE_P
-            self.selectionOperator=tools.selNSGA2
-            self.parentSelectionOperator=tools.selTournamentDCD
+            self.matingOperator = tools.cxSimulatedBinaryBounded
+            self.MATE_P = {
+                "low": self.parameterSpace.lowerBound,
+                "up": self.parameterSpace.upperBound,
+                "eta": 20.0,
+            } or MATE_P
+            self.mutationOperator = tools.mutPolynomialBounded
+            self.MUTATE_P = {
+                "low": self.parameterSpace.lowerBound,
+                "up": self.parameterSpace.upperBound,
+                "eta": 20.0,
+                "indpb": 1.0 / len(self.weightList),
+            } or MUTATE_P
+            self.selectionOperator = tools.selNSGA2
+            self.parentSelectionOperator = tools.selTournamentDCD
             self.individualGenerator = du.randomParameters
-        
+
         else:
-            raise ValueError("Evolution: algorithm must be one of the following: ['adaptive', 'nsga2']")
+            raise ValueError(
+                "Evolution: algorithm must be one of the following: ['adaptive', 'nsga2']"
+            )
 
         # if the operators are set manually, then overwrite them
-        self.matingOperator = self.matingOperator if hasattr(self, "matingOperator") else matingOperator
-        self.mutationOperator = self.mutationOperator if hasattr(self, "mutationOperator") else mutationOperator
-        self.selectionOperator = self.selectionOperator if hasattr(self, "selectionOperator") else selectionOperator
-        self.parentSelectionOperator = self.parentSelectionOperator if hasattr(self, "parentSelectionOperator") else parentSelectionOperator
-        self.individualGenerator = self.individualGenerator if hasattr(self, "individualGenerator") else individualGenerator
+        self.matingOperator = (
+            self.matingOperator if hasattr(self, "matingOperator") else matingOperator
+        )
+        self.mutationOperator = (
+            self.mutationOperator
+            if hasattr(self, "mutationOperator")
+            else mutationOperator
+        )
+        self.selectionOperator = (
+            self.selectionOperator
+            if hasattr(self, "selectionOperator")
+            else selectionOperator
+        )
+        self.parentSelectionOperator = (
+            self.parentSelectionOperator
+            if hasattr(self, "parentSelectionOperator")
+            else parentSelectionOperator
+        )
+        self.individualGenerator = (
+            self.individualGenerator
+            if hasattr(self, "individualGenerator")
+            else individualGenerator
+        )
 
         # let's also make sure that the parameters are set correctly
         self.MATE_P = self.MATE_P if hasattr(self, "MATE_P") else {}
-        self.PARENT_SELECT_P = self.PARENT_SELECT_P if hasattr(self, "PARENT_SELECT_P") else {}
+        self.PARENT_SELECT_P = (
+            self.PARENT_SELECT_P if hasattr(self, "PARENT_SELECT_P") else {}
+        )
         self.MUTATE_P = self.MUTATE_P if hasattr(self, "MUTATE_P") else {}
         self.SELECT_P = self.SELECT_P if hasattr(self, "SELECT_P") else {}
-
 
         self.initDEAP(
             self.toolbox,
@@ -208,7 +241,7 @@ class Evolution:
             mutationOperator=self.mutationOperator,
             selectionOperator=self.selectionOperator,
             parentSelectionOperator=self.parentSelectionOperator,
-            individualGenerator=self.individualGenerator
+            individualGenerator=self.individualGenerator,
         )
 
         # set up pypet trajectory
@@ -230,7 +263,7 @@ class Evolution:
         :param verbose: Print and plot state of evolution during run, defaults to False
         :type verbose: bool, optional
         """
-        
+
         self.verbose = verbose
         if not self._initialPopulationSimulated:
             self.runInitial()
@@ -279,7 +312,11 @@ class Evolution:
         :return: Parameter dictionary of this individual
         :rtype: dict
         """
-        return self.ParametersInterval(*(individual[: len(self.paramInterval)]))._asdict().copy()
+        return (
+            self.ParametersInterval(*(individual[: len(self.paramInterval)]))
+            ._asdict()
+            .copy()
+        )
 
     def initPypetTrajectory(self, traj, paramInterval, POP_SIZE, NGEN, model):
         """Initializes pypet trajectory and store all simulation parameters for later analysis.
@@ -304,26 +341,44 @@ class Evolution:
         # Placeholders for individuals and results that are about to be explored
         traj.f_add_parameter("generation", 0, comment="Current generation")
 
-        traj.f_add_result("scores", [], comment="Score of all individuals for each generation")
-        traj.f_add_result_group("evolution", comment="Contains results for each generation")
+        traj.f_add_result(
+            "scores", [], comment="Score of all individuals for each generation"
+        )
+        traj.f_add_result_group(
+            "evolution", comment="Contains results for each generation"
+        )
         traj.f_add_result_group("outputs", comment="Contains simulation results")
 
-        #TODO: save evolution parameters and operators as well, MATE_P, MUTATE_P, etc..
+        # TODO: save evolution parameters and operators as well, MATE_P, MUTATE_P, etc..
 
         # if a model was given, save its parameters
         # NOTE: Convert model.params to dict() since it is a dotdict() and pypet doesn't like that
         if model is not None:
-            traj.f_add_result("params", dict(model.params), comment="Default parameters")
+            traj.f_add_result(
+                "params", dict(model.params), comment="Default parameters"
+            )
 
         # todo: initialize this after individuals have been defined!
         traj.f_add_parameter("id", 0, comment="Index of individual")
         traj.f_add_parameter("ind_len", 20, comment="Length of individual")
         traj.f_add_derived_parameter(
-            "individual", [0 for x in range(traj.ind_len)], "An indivudal of the population",
+            "individual",
+            [0 for x in range(traj.ind_len)],
+            "An indivudal of the population",
         )
 
     def initDEAP(
-        self, toolbox, pypetEnvironment, paramInterval, evalFunction, weightList, matingOperator, mutationOperator, selectionOperator, parentSelectionOperator, individualGenerator
+        self,
+        toolbox,
+        pypetEnvironment,
+        paramInterval,
+        evalFunction,
+        weightList,
+        matingOperator,
+        mutationOperator,
+        selectionOperator,
+        parentSelectionOperator,
+        individualGenerator,
     ):
         """Initializes DEAP and registers all methods to the deap.toolbox
         
@@ -344,7 +399,9 @@ class Evolution:
         :param individualGenerator: Function that generates individuals
         """
         # ------------- register everything in deap
-        deap.creator.create("FitnessMulti", deap.base.Fitness, weights=tuple(weightList))
+        deap.creator.create(
+            "FitnessMulti", deap.base.Fitness, weights=tuple(weightList)
+        )
         deap.creator.create("Individual", list, fitness=deap.creator.FitnessMulti)
 
         # initially, each individual has randomized genes
@@ -361,10 +418,10 @@ class Evolution:
         toolbox.register("population", deap.tools.initRepeat, list, toolbox.individual)
         toolbox.register("map", pypetEnvironment.run)
         toolbox.register("evaluate", evalFunction)
-        toolbox.register("run_map", pypetEnvironment.run_map)        
+        toolbox.register("run_map", pypetEnvironment.run_map)
 
         # Operator registering
-        
+
         toolbox.register("mate", matingOperator)
         logging.info(f"Evolution: Mating operator: {matingOperator}")
 
@@ -376,7 +433,6 @@ class Evolution:
         logging.info(f"Evolution: Parent selection: {parentSelectionOperator}")
         toolbox.register("select", selectionOperator)
         logging.info(f"Evolution: Selection operator: {selectionOperator}")
-
 
     def evalPopulationUsingPypet(self, traj, toolbox, pop, gIdx):
         """Evaluate the fitness of the popoulation of the current generation using pypet
@@ -407,8 +463,11 @@ class Evolution:
 
         traj.f_expand(
             pp.cartesian_product(
-                {"generation": [gIdx], "id": [x.id for x in pop], 
-                "individual": [list(_cleanIndividual(x)) for x in pop],},
+                {
+                    "generation": [gIdx],
+                    "id": [x.id for x in pop],
+                    "individual": [list(_cleanIndividual(x)) for x in pop],
+                },
                 [("id", "individual"), "generation"],
             )
         )  # the current generation  # unique id of each individual
@@ -442,7 +501,9 @@ class Evolution:
             pop[idx].fitness.values = fitnessesResult
 
             # compute score
-            pop[idx].fitness.score = np.ma.masked_invalid(pop[idx].fitness.wvalues).sum() / (len(pop[idx].fitness.wvalues))
+            pop[idx].fitness.score = np.ma.masked_invalid(
+                pop[idx].fitness.wvalues
+            ).sum() / (len(pop[idx].fitness.wvalues))
         return pop
 
     def getValidPopulation(self, pop=None):
@@ -454,7 +515,13 @@ class Evolution:
         :rtype: list
         """
         pop = pop or self.pop
-        return [p for p in pop if not (np.isnan(p.fitness.values).any() or np.isinf(p.fitness.values).any()) ]
+        return [
+            p
+            for p in pop
+            if not (
+                np.isnan(p.fitness.values).any() or np.isinf(p.fitness.values).any()
+            )
+        ]
 
     def getInvalidPopulation(self, pop=None):
         """Returns a list of the invalid population.
@@ -463,9 +530,13 @@ class Evolution:
         :type pop: deap population
         :return: List of invalid population
         :rtype: list
-        """        
+        """
         pop = pop or self.pop
-        return [p for p in pop if np.isnan(p.fitness.values).any() or np.isinf(p.fitness.values).any()]
+        return [
+            p
+            for p in pop
+            if np.isnan(p.fitness.values).any() or np.isinf(p.fitness.values).any()
+        ]
 
     def tagPopulation(self, pop):
         """Take a fresh population and add id's and attributes such as parameters that we can use later
@@ -476,7 +547,9 @@ class Evolution:
         :rtype: list
         """
         for i, ind in enumerate(pop):
-            assert not hasattr(ind, "id"), "Individual has an id already, will not overwrite it!"
+            assert not hasattr(
+                ind, "id"
+            ), "Individual has an id already, will not overwrite it!"
             ind.id = self.last_id
             ind.gIdx = self.gIdx
             ind.simulation_stored = False
@@ -504,7 +577,9 @@ class Evolution:
         self.pop = self.tagPopulation(self.pop)
 
         # evaluate
-        self.pop = self.evalPopulationUsingPypet(self.traj, self.toolbox, self.pop, self.gIdx)
+        self.pop = self.evalPopulationUsingPypet(
+            self.traj, self.toolbox, self.pop, self.gIdx
+        )
 
         if self.verbose:
             eu.printParamDist(self.pop, self.paramInterval, self.gIdx)
@@ -518,7 +593,7 @@ class Evolution:
         self._initialPopulationSimulated = True
 
         # populate history for tracking
-        self.history[self.gIdx] = self.pop #self.getValidPopulation(self.pop)
+        self.history[self.gIdx] = self.pop  # self.getValidPopulation(self.pop)
 
         self._t_end_initial_population = datetime.datetime.now()
 
@@ -533,20 +608,27 @@ class Evolution:
             validpop = self.getValidPopulation(self.pop)
             # replace invalid individuals
             invalidpop = self.getInvalidPopulation(self.pop)
-            
+
             logging.info("Replacing {} invalid individuals.".format(len(invalidpop)))
             newpop = self.toolbox.population(n=len(invalidpop))
             newpop = self.tagPopulation(newpop)
 
             # ------- Create the next generation by crossover and mutation -------- #
             ### Select parents using rank selection and clone them ###
-            offspring = list(map(self.toolbox.clone, self.toolbox.selectParents(self.pop, self.POP_SIZE, **self.PARENT_SELECT_P)))
-            
-
+            offspring = list(
+                map(
+                    self.toolbox.clone,
+                    self.toolbox.selectParents(
+                        self.pop, self.POP_SIZE, **self.PARENT_SELECT_P
+                    ),
+                )
+            )
 
             ##### cross-over ####
             for i in range(1, len(offspring), 2):
-                offspring[i - 1], offspring[i] = self.toolbox.mate(offspring[i - 1], offspring[i], **self.MATE_P)
+                offspring[i - 1], offspring[i] = self.toolbox.mate(
+                    offspring[i - 1], offspring[i], **self.MATE_P
+                )
                 # delete fitness inherited from parents
                 del offspring[i - 1].fitness.values, offspring[i].fitness.values
                 del offspring[i - 1].fitness.wvalues, offspring[i].fitness.wvalues
@@ -561,26 +643,32 @@ class Evolution:
 
             ##### Mutation ####
             # Apply mutation
-            du.mutateUntilValid(offspring, self.paramInterval, self.toolbox, MUTATE_P=self.MUTATE_P)
+            du.mutateUntilValid(
+                offspring, self.paramInterval, self.toolbox, MUTATE_P=self.MUTATE_P
+            )
 
             offspring = self.tagPopulation(offspring)
 
             # ------- Evaluate next generation -------- #
 
             self.pop = offspring + newpop
-            self.evalPopulationUsingPypet(self.traj, self.toolbox, offspring + newpop, self.gIdx)
+            self.evalPopulationUsingPypet(
+                self.traj, self.toolbox, offspring + newpop, self.gIdx
+            )
 
             # log individuals
-            self.history[self.gIdx] = validpop + offspring + newpop  # self.getValidPopulation(self.pop)            
+            self.history[self.gIdx] = (
+                validpop + offspring + newpop
+            )  # self.getValidPopulation(self.pop)
 
             # ------- Select surviving population -------- #
 
             # select next generation
-            self.pop = self.toolbox.select(validpop + offspring + newpop, k=self.traj.popsize, **self.SELECT_P)
+            self.pop = self.toolbox.select(
+                validpop + offspring + newpop, k=self.traj.popsize, **self.SELECT_P
+            )
 
             # ------- END OF ROUND -------
-
-
 
             # save all simulation data to pypet
             self.pop = eu.saveToPypet(self.traj, self.pop, self.gIdx)
@@ -601,7 +689,9 @@ class Evolution:
                 self.info(plot=True, info=True)
 
         logging.info("--- End of evolution ---")
-        logging.info("Best individual is %s, %s" % (self.best_ind, self.best_ind.fitness.values))
+        logging.info(
+            "Best individual is %s, %s" % (self.best_ind, self.best_ind.fitness.values)
+        )
         logging.info("--- End of evolution ---")
 
         self.traj.f_store()  # We switched off automatic storing, so we need to store manually
@@ -635,7 +725,6 @@ class Evolution:
                 self.id_genx[p.id] = p.gIdx
                 self.id_score[p.id] = p.fitness.score
 
-
     def info(self, plot=True, bestN=5, info=True, reverse=False):
         """Print and plot information about the evolution and the current population
         
@@ -663,10 +752,20 @@ class Evolution:
         if plot:
             # hack: during the evolution we need to use reverse=True
             # after the evolution (with evolution.info()), we need False
-            self.plotProgress(reverse=reverse)
-            eu.plotPopulation(self, plotScattermatrix=True, save_plots=self.trajectoryName, color=self.plotColor)
+            try:
+                self.plotProgress(reverse=reverse)
+            except:
+                logging.warn(
+                    "Could not plot progress, is this a previously saved simulation?"
+                )
+            eu.plotPopulation(
+                self,
+                plotScattermatrix=True,
+                save_plots=self.trajectoryName,
+                color=self.plotColor,
+            )
 
-    def plotProgress(self, reverse=True):
+    def plotProgress(self, reverse=False):
         """Plots progress of fitnesses of current evolution run
         """
         eu.plotProgress(self, reverse=reverse)
@@ -678,8 +777,11 @@ class Evolution:
         :type fname: str, optional
         """
         import dill
-        fname = fname or os.path.join("data/", "evolution-" + self.trajectoryName + ".dill")
-        dill.dump(self, open(fname, "wb"))        
+
+        fname = fname or os.path.join(
+            "data/", "evolution-" + self.trajectoryName + ".dill"
+        )
+        dill.dump(self, open(fname, "wb"))
         logging.info(f"Saving evolution to {fname}")
 
     def loadEvolution(self, fname):
@@ -700,33 +802,112 @@ class Evolution:
         :rtype: self
         """
         import dill
+
         evolution = dill.load(open(fname, "rb"))
-        evolution.__init__(lambda x: x, self.parameterSpace)
+
+        # parameter space is not saved correctly in dill, don't know why
+        # that is why we recreate it using the values of
+        # the parameter space in the dill
+        from neurolib.utils.parameterSpace import ParameterSpace
+
+        pars = ParameterSpace(
+            evolution.parameterSpace.parameterNames,
+            evolution.parameterSpace.parameterValues,
+        )
+
+        evolution.parameterSpace = pars
+        evolution.paramInterval = evolution.parameterSpace.named_tuple
+        # # we reinitialize the evolution with the arguments of the saved evolution
+        # evolution.__init__(
+        #     evalFunction=evolution.evalFunction,
+        #     parameterSpace=pars,
+        #     weightList=evolution.weightList,
+        #     model=evolution.model,
+        #     ncores=evolution.ncores,
+        #     POP_INIT_SIZE=evolution.POP_INIT_SIZE,
+        #     POP_SIZE=evolution.POP_SIZE,
+        #     NGEN=evolution.NGEN,
+        #     matingOperator=evolution.matingOperator,
+        #     MATE_P=evolution.MATE_P,
+        #     mutationOperator=evolution.mutationOperator,
+        #     MUTATE_P=evolution.MUTATE_P,
+        #     selectionOperator=evolution.selectionOperator,
+        #     SELECT_P=evolution.SELECT_P,
+        #     parentSelectionOperator=evolution.parentSelectionOperator,
+        #     PARENT_SELECT_P=evolution.PARENT_SELECT_P,
+        #     individualGenerator=evolution.individualGenerator,
+        # )
+
         return evolution
 
     @property
     def dfPop(self):
-        """Returns a `pandas` dataframe of the current generation's population parameters 
-        for post processing. This object can be further used to easily analyse the population.
-        :return: Pandas dataframe with all individuals and their parameters
+        """Returns a `pandas` DataFrame of the current generation's population parameters. 
+        This object can be further used to easily analyse the population.
+        :return: Pandas DataFrame with all individuals and their parameters
         :rtype: `pandas.core.frame.DataFrame`
         """
+        # add the current population to the dataframe
         validPop = self.getValidPopulation(self.pop)
         indIds = [p.id for p in validPop]
-        popArray = np.array([p[0 : len(self.paramInterval._fields)] for p in validPop]).T
-        scores = self.getScores()
-        
+        popArray = np.array(
+            [p[0 : len(self.paramInterval._fields)] for p in validPop]
+        ).T
+
         dfPop = pd.DataFrame(popArray, index=self.parameterSpace.parameterNames).T
+
+        # add more information to the dataframe
+        scores = self.getScores()
         dfPop["score"] = scores
         dfPop["id"] = indIds
+        dfPop["gen"] = [p.gIdx for p in validPop]
 
         # add fitness columns
-        n_fitnesses = len(self.pop[0].fitness.values)
+        # NOTE: when loading an evolution with dill using loadingEvolution
+        # MultiFitness values dissappear and only one is left.
+        # See dfEvolution() for a solution using wvalues
+        n_fitnesses = len(validPop[0].fitness.values)
         for i in range(n_fitnesses):
-            for ip, p in enumerate(self.pop):
+            for ip, p in enumerate(validPop):
                 column_name = "f" + str(i)
                 dfPop.loc[ip, column_name] = p.fitness.values[i]
         return dfPop
+
+    @property
+    def dfEvolution(self):
+        """Returns a `pandas` DataFrame with the individuals of the the whole evolution.
+        This method can be usef after loading an evolution from disk using loadEvolution()
+
+        :return: Pandas DataFrame with all individuals and their parameters
+        :rtype: `pandas.core.frame.DataFrame`
+        """
+        parameters = self.parameterSpace.parameterNames
+        allIndividuals = [p for gen, pop in self.history.items() for p in pop]
+        popArray = np.array(
+            [p[0 : len(self.paramInterval._fields)] for p in allIndividuals]
+        ).T
+        dfEvolution = pd.DataFrame(popArray, index=parameters).T
+        # add more information to the dataframe
+        scores = [float(p.fitness.score) for p in allIndividuals]
+        indIds = [p.id for p in allIndividuals]
+        dfEvolution["score"] = scores
+        dfEvolution["id"] = indIds
+        dfEvolution["gen"] = [p.gIdx for p in allIndividuals]
+
+        # add fitness columns
+        # NOTE: have to do this with wvalues and divide by weights later, why?
+        # Because after loading the evolution with dill, somehow multiple fitnesses
+        # dissappear and only the first one is left. However, wvalues still has all
+        # fitnesses, and we have acces to weightList, so this hack kind of helps
+        n_fitnesses = len(self.pop[0].fitness.wvalues)
+        for i in range(n_fitnesses):
+            for ip, p in enumerate(allIndividuals):
+                column_name = "f" + str(i)
+                dfEvolution.loc[ip, column_name] = (
+                    p.fitness.wvalues[i] / self.weightList[i]
+                )
+
+        return dfEvolution
 
     def loadResults(self, filename=None, trajectoryName=None):
         """Load results from a hdf file of a previous evolution and store the

--- a/neurolib/optimize/evolution/evolution.py
+++ b/neurolib/optimize/evolution/evolution.py
@@ -944,7 +944,7 @@ class Evolution:
 
         if reverse:
             generation_names = generation_names[::-1]
-        if drop_first:
+        if drop_first and "gen_000000" in generation_names:
             generation_names.remove("gen_000000")
 
         npop = len(traj.results.evolution[generation_names[0]].scores)

--- a/neurolib/optimize/evolution/evolution.py
+++ b/neurolib/optimize/evolution/evolution.py
@@ -902,10 +902,7 @@ class Evolution:
         n_fitnesses = len(self.pop[0].fitness.wvalues)
         for i in range(n_fitnesses):
             for ip, p in enumerate(allIndividuals):
-                column_name = "f" + str(i)
-                dfEvolution.loc[ip, column_name] = (
-                    p.fitness.wvalues[i] / self.weightList[i]
-                )
+                dfEvolution.loc[ip, f"f{i}"] = p.fitness.wvalues[i] / self.weightList[i]
 
         return dfEvolution
 

--- a/neurolib/optimize/evolution/evolutionaryUtils.py
+++ b/neurolib/optimize/evolution/evolutionaryUtils.py
@@ -10,7 +10,7 @@ from . import deapUtils as du
 
 def saveToPypet(traj, pop, gIdx):
     try:
-        traj.f_add_result_group("evolution.gen_{:06d}")
+        traj.f_add_result_group(f"evolution.gen_{gIdx:06d}")
         traj.f_add_result(
             f"evolution.gen_{gIdx:06d}.fitness",
             np.array([p.fitness.values for p in pop]),
@@ -58,7 +58,7 @@ def saveToPypet(traj, pop, gIdx):
 
 
 def printParamDist(pop=None, paramInterval=None, gIdx=None):
-    print("Parameter distribution (Generation {}):")
+    print(f"Parameter distribution (Generation {gIdx}):")
     for idx, k in enumerate(paramInterval._fields):
         mean_params = np.mean([indiv[idx] for indiv in pop])
         sdt_params = np.std([indiv[idx] for indiv in pop])

--- a/neurolib/optimize/evolution/evolutionaryUtils.py
+++ b/neurolib/optimize/evolution/evolutionaryUtils.py
@@ -11,10 +11,22 @@ from . import deapUtils as du
 def saveToPypet(traj, pop, gIdx):
     try:
         traj.f_add_result_group("{}.gen_{:06d}".format("evolution", gIdx))
-        traj.f_add_result("{}.gen_{:06d}.fitness".format("evolution", gIdx), np.array([p.fitness.values for p in pop]))
-        traj.f_add_result("{}.gen_{:06d}.scores".format("evolution", gIdx), np.array([p.fitness.score for p in pop]))
-        traj.f_add_result("{}.gen_{:06d}.population".format("evolution", gIdx), np.array([list(p) for p in pop]))
-        traj.f_add_result("{}.gen_{:06d}.ind_ids".format("evolution", gIdx), np.array([p.id for p in pop]))
+        traj.f_add_result(
+            "{}.gen_{:06d}.fitness".format("evolution", gIdx),
+            np.array([p.fitness.values for p in pop]),
+        )
+        traj.f_add_result(
+            "{}.gen_{:06d}.scores".format("evolution", gIdx),
+            np.array([p.fitness.score for p in pop]),
+        )
+        traj.f_add_result(
+            "{}.gen_{:06d}.population".format("evolution", gIdx),
+            np.array([list(p) for p in pop]),
+        )
+        traj.f_add_result(
+            "{}.gen_{:06d}.ind_ids".format("evolution", gIdx),
+            np.array([p.id for p in pop]),
+        )
         # recursively store all simulated outputs into hdf
         for i, p in enumerate(pop):
             if not np.isnan(p.fitness.values).any() and not p.simulation_stored:
@@ -22,7 +34,9 @@ def saveToPypet(traj, pop, gIdx):
 
                 traj.f_add_result_group("{}.ind_{:06d}".format("outputs", p.id))
 
-                assert isinstance(p.outputs, dict), "outputs are not a dict, can't unpack!"
+                assert isinstance(
+                    p.outputs, dict
+                ), "outputs are not a dict, can't unpack!"
 
                 def unpackOutputsAndStore(outputs, save_string):
                     new_save_string = save_string
@@ -32,9 +46,13 @@ def saveToPypet(traj, pop, gIdx):
                             traj.f_add_result_group(new_save_string)
                             unpackOutputsAndStore(value, new_save_string)
                         else:
-                            traj.f_add_result("{}.{}".format(new_save_string, key), value)
+                            traj.f_add_result(
+                                "{}.{}".format(new_save_string, key), value
+                            )
 
-                unpackOutputsAndStore(p.outputs, save_string="{}.ind_{:06d}".format("outputs", p.id))
+                unpackOutputsAndStore(
+                    p.outputs, save_string="{}.ind_{:06d}".format("outputs", p.id)
+                )
 
         traj.f_store()
     except:
@@ -50,7 +68,9 @@ def printParamDist(pop=None, paramInterval=None, gIdx=None):
     for idx, k in enumerate(paramInterval._fields):
         print(
             "{}: \t mean: {:.4},\t std: {:.4}".format(
-                k, np.mean([indiv[idx] for indiv in pop]), np.std([indiv[idx] for indiv in pop]),
+                k,
+                np.mean([indiv[idx] for indiv in pop]),
+                np.std([indiv[idx] for indiv in pop]),
             )
         )
 
@@ -59,18 +79,19 @@ def printIndividuals(pop, paramInterval, stats=True):
     print("Printing {} individuals".format(len(pop)))
     for i, ind in enumerate(pop):
         print(f"Individual {i}")
-        
+
         print("\tFitness values: ", *np.round(ind.fitness.values, 2))
         if stats:
             print("\tScore: ", np.round(ind.fitness.score, 2))
             print("\tWeighted fitness: ", *np.round(ind.fitness.wvalues, 2))
-            print(f"\tStats mean {np.mean(ind.fitness.values):.2f} std {np.std(ind.fitness.values):.2f} min {np.min(ind.fitness.values):.2f} max {np.max(ind.fitness.values):.2f}")
+            print(
+                f"\tStats mean {np.mean(ind.fitness.values):.2f} std {np.std(ind.fitness.values):.2f} min {np.min(ind.fitness.values):.2f} max {np.max(ind.fitness.values):.2f}"
+            )
         for ki, k in enumerate(paramInterval._fields):
-            print(f"\tmodel.params[\"{k}\"] = {ind[ki]:.2f}")
-        
+            print(f'\tmodel.params["{k}"] = {ind[ki]:.2f}')
 
 
-def plotScoresDistribution(scores, gIdx, save_plots=None, color='C0'):
+def plotScoresDistribution(scores, gIdx, save_plots=None, color="C0"):
     import matplotlib.pyplot as plt
 
     plt.figure(figsize=(4, 2))
@@ -79,21 +100,41 @@ def plotScoresDistribution(scores, gIdx, save_plots=None, color='C0'):
     plt.xlabel("Score")
     plt.ylabel("Count")
     if save_plots is not None:
-        logging.info("Saving plot to {}".format(os.path.join(paths.FIGURES_DIR, "%s_hist_%i.png" % (save_plots, gIdx))))
-        plt.savefig(os.path.join(paths.FIGURES_DIR, "%s_hist_%i.png" % (save_plots, gIdx)))
+        logging.info(
+            "Saving plot to {}".format(
+                os.path.join(paths.FIGURES_DIR, "%s_hist_%i.png" % (save_plots, gIdx))
+            )
+        )
+        plt.savefig(
+            os.path.join(paths.FIGURES_DIR, "%s_hist_%i.png" % (save_plots, gIdx))
+        )
     plt.show()
 
 
-def plotSeabornScatter1(evolution, vars, save_plots, color='C0'):
+def plotSeabornScatter1(evolution, dfPop=None, save_plots=None, color="C0"):
     import matplotlib.pyplot as plt
     import seaborn as sns
 
+    vars = list(evolution.parameterSpace.dict().keys())
+
+    # dfPop = dfPop or evolution.dfPop does not work!
+    if dfPop is not None:
+        dfPop = dfPop
+    else:
+        dfPop = evolution.dfPop
+
     fig = plt.figure()
-    sm = sns.pairplot(evolution.dfPop, vars=vars, 
-                    diag_kind="kde", kind="reg", 
-                    plot_kws={'line_kws':{'color': color}, 
-                    'scatter_kws': {'alpha': 0.5, 'color' : color}},
-                    diag_kws={'color' :  color})
+    sm = sns.pairplot(
+        dfPop,
+        vars=vars,
+        diag_kind="kde",
+        kind="reg",
+        plot_kws={
+            "line_kws": {"color": color},
+            "scatter_kws": {"alpha": 0.5, "color": color},
+        },
+        diag_kws={"color": color},
+    )
 
     # adjust axis to parameter boundaries
     for axi, ax in enumerate(sm.axes):
@@ -102,14 +143,26 @@ def plotSeabornScatter1(evolution, vars, save_plots, color='C0'):
             ay.set_xlim(evolution.paramInterval[ayi])
 
     if save_plots is not None:
-        plt.savefig(os.path.join(paths.FIGURES_DIR, "{}_sns_params_{}.png".format(save_plots, evolution.gIdx)), bbox_inches='tight')
+        plt.savefig(
+            os.path.join(
+                paths.FIGURES_DIR,
+                "{}_sns_params_{}.png".format(save_plots, evolution.gIdx),
+            ),
+            bbox_inches="tight",
+        )
     plt.show()
 
 
-def plotSeabornScatter2(evolution, vars, save_plots, color='C0'):
+def plotSeabornScatter2(evolution, dfPop=None, save_plots=None, color="C0"):
     import matplotlib.pyplot as plt
     import seaborn as sns
 
+    vars = list(evolution.parameterSpace.dict().keys())
+    # dfPop = dfPop or evolution.dfPop does not work!
+    if dfPop is not None:
+        dfPop = dfPop
+    else:
+        dfPop = evolution.dfPop
     # https://towardsdatascience.com/visualizing-data-with-pair-plots-in-python-f228cf529166
     grid = sns.PairGrid(data=evolution.dfPop, vars=vars)
     grid = grid.map_upper(plt.scatter, color=color, alpha=0.5)
@@ -125,14 +178,25 @@ def plotSeabornScatter2(evolution, vars, save_plots, color='C0'):
                 ay.set_ylim(evolution.paramInterval[axi])
                 ay.set_xlim(evolution.paramInterval[ayi])
             except:
-                pass 
+                pass
     if save_plots is not None:
-        plt.savefig(os.path.join(paths.FIGURES_DIR, "{}_sns_params_red_{}.png".format(save_plots, evolution.gIdx)), bbox_inches='tight')
+        plt.savefig(
+            os.path.join(
+                paths.FIGURES_DIR,
+                "{}_sns_params_red_{}.png".format(save_plots, evolution.gIdx),
+            ),
+            bbox_inches="tight",
+        )
     plt.show()
 
 
 def plotPopulation(
-    evolution, plotDistribution=True, plotScattermatrix=False, save_plots=None, color='C0'
+    evolution,
+    history=False,
+    plotDistribution=True,
+    plotScattermatrix=False,
+    save_plots=None,
+    color="C0",
 ):
 
     """
@@ -149,12 +213,13 @@ def plotPopulation(
 
     # plots can only be drawn if there are enough individuals, to avoid errors
     MIN_POP_SIZE_PLOTTING = 4
-    vars_to_plot = list(evolution.parameterSpace.dict().keys())
 
     if len(validPop) > MIN_POP_SIZE_PLOTTING and plotDistribution:
-        plotScoresDistribution(scores, evolution.gIdx, save_plots=save_plots, color=color)
-        plotSeabornScatter1(evolution, vars=vars_to_plot, save_plots=save_plots, color=color)
-        plotSeabornScatter2(evolution, vars=vars_to_plot, save_plots=save_plots, color=color)
+        plotScoresDistribution(
+            scores, evolution.gIdx, save_plots=save_plots, color=color
+        )
+        plotSeabornScatter1(evolution, save_plots=save_plots, color=color)
+        plotSeabornScatter2(evolution, save_plots=save_plots, color=color)
 
 
 def plotProgress(evolution, reverse=True):
@@ -162,14 +227,27 @@ def plotProgress(evolution, reverse=True):
 
     gens, all_scores = evolution.getScoresDuringEvolution(reverse=reverse)
 
-    fig, axs = plt.subplots(2, 1, figsize=(3.5, 3), dpi=150, sharex=True, gridspec_kw={"height_ratios" : [2, 1]})   
-    im = axs[0].imshow(all_scores.T, aspect='auto', origin='lower')
+    fig, axs = plt.subplots(
+        2,
+        1,
+        figsize=(3.5, 3),
+        dpi=150,
+        sharex=True,
+        gridspec_kw={"height_ratios": [2, 1]},
+    )
+    im = axs[0].imshow(all_scores.T, aspect="auto", origin="lower")
     axs[0].set_ylabel("Individuals")
     cbar_ax = fig.add_axes([0.93, 0.42, 0.02, 0.3])
-    fig.colorbar(im, cax=cbar_ax, label='Score')
+    fig.colorbar(im, cax=cbar_ax, label="Score")
 
-    axs[1].plot(gens, np.nanmean(all_scores, axis=1), label='Average')
-    axs[1].fill_between(gens, np.nanmin(all_scores, axis=1), np.nanmax(all_scores, axis=1), alpha=0.3, label='Bound')
+    axs[1].plot(gens, np.nanmean(all_scores, axis=1), label="Average")
+    axs[1].fill_between(
+        gens,
+        np.nanmin(all_scores, axis=1),
+        np.nanmax(all_scores, axis=1),
+        alpha=0.3,
+        label="Bound",
+    )
     axs[1].set_xlabel("Generation")
     axs[1].set_ylabel("Score")
     plt.show()
@@ -187,14 +265,16 @@ def printEvolutionInfo(evolution):
             f"Duration of evaluating initial population {evolution._t_end_initial_population-evolution._t_start_initial_population}"
         )
     if hasattr(evolution, "_t_end_evolution"):
-        print(f"Duration of evolution {evolution._t_end_evolution-evolution._t_start_evolution}")
+        print(
+            f"Duration of evolution {evolution._t_end_evolution-evolution._t_start_evolution}"
+        )
     if evolution.model is not None:
         print(f"Model: {type(evolution.model)}")
         if hasattr(evolution.model, "name"):
             if isinstance(evolution.model.name, str):
                 print(f"Model name: {evolution.model.name}")
     print(f"Eval function: {evolution.evalFunction}")
-    print(f"Parameter space: {evolution.paramInterval}")
+    print(f"Parameter space: {evolution.parameterSpace}")
     # print(f"Weights: {evolution.weightList}")
     print("> Evolution parameters")
     print(f"Number of generations: {evolution.NGEN}")

--- a/neurolib/optimize/evolution/evolutionaryUtils.py
+++ b/neurolib/optimize/evolution/evolutionaryUtils.py
@@ -10,29 +10,27 @@ from . import deapUtils as du
 
 def saveToPypet(traj, pop, gIdx):
     try:
-        traj.f_add_result_group("{}.gen_{:06d}".format("evolution", gIdx))
+        traj.f_add_result_group("evolution.gen_{:06d}")
         traj.f_add_result(
-            "{}.gen_{:06d}.fitness".format("evolution", gIdx),
+            f"evolution.gen_{gIdx:06d}.fitness",
             np.array([p.fitness.values for p in pop]),
         )
         traj.f_add_result(
-            "{}.gen_{:06d}.scores".format("evolution", gIdx),
+            f"evolution.gen_{gIdx:06d}.scores",
             np.array([p.fitness.score for p in pop]),
         )
         traj.f_add_result(
-            "{}.gen_{:06d}.population".format("evolution", gIdx),
-            np.array([list(p) for p in pop]),
+            f"evolution.gen_{gIdx:06d}.population", np.array([list(p) for p in pop]),
         )
         traj.f_add_result(
-            "{}.gen_{:06d}.ind_ids".format("evolution", gIdx),
-            np.array([p.id for p in pop]),
+            f"evolution.gen_{gIdx:06d}.ind_ids", np.array([p.id for p in pop]),
         )
         # recursively store all simulated outputs into hdf
         for i, p in enumerate(pop):
             if not np.isnan(p.fitness.values).any() and not p.simulation_stored:
                 pop[i].simulation_stored = True
 
-                traj.f_add_result_group("{}.ind_{:06d}".format("outputs", p.id))
+                traj.f_add_result_group(f"outputs.ind_{p.id:06d}"
 
                 assert isinstance(
                     p.outputs, dict
@@ -47,11 +45,11 @@ def saveToPypet(traj, pop, gIdx):
                             unpackOutputsAndStore(value, new_save_string)
                         else:
                             traj.f_add_result(
-                                "{}.{}".format(new_save_string, key), value
+                                f"{new_save_string}.{key}", value
                             )
 
                 unpackOutputsAndStore(
-                    p.outputs, save_string="{}.ind_{:06d}".format("outputs", p.id)
+                    p.outputs, save_string=f"outputs.ind_{p.id:06d}"
                 )
 
         traj.f_store()
@@ -64,19 +62,17 @@ def saveToPypet(traj, pop, gIdx):
 
 
 def printParamDist(pop=None, paramInterval=None, gIdx=None):
-    print("Parameter distribution (Generation {}):".format(gIdx))
+    print("Parameter distribution (Generation {}):")
     for idx, k in enumerate(paramInterval._fields):
+        mean_params = np.mean([indiv[idx] for indiv in pop])
+        sdt_params = np.std([indiv[idx] for indiv in pop])
         print(
-            "{}: \t mean: {:.4},\t std: {:.4}".format(
-                k,
-                np.mean([indiv[idx] for indiv in pop]),
-                np.std([indiv[idx] for indiv in pop]),
-            )
+            f"{k}: \t mean: {mean_params:.4f},\t std: {sdt_params:.4f}"
         )
 
 
 def printIndividuals(pop, paramInterval, stats=True):
-    print("Printing {} individuals".format(len(pop)))
+    print(f"Printing {len(pop)} individuals")
     for i, ind in enumerate(pop):
         print(f"Individual {i}")
 
@@ -100,13 +96,12 @@ def plotScoresDistribution(scores, gIdx, save_plots=None, color="C0"):
     plt.xlabel("Score")
     plt.ylabel("Count")
     if save_plots is not None:
+        save_fname = os.path.join(paths.FIGURES_DIR, f"{save_plots}_hist_{gIdx}.png"
         logging.info(
-            "Saving plot to {}".format(
-                os.path.join(paths.FIGURES_DIR, "%s_hist_%i.png" % (save_plots, gIdx))
+            f"Saving plot to {save_fname}"
             )
         )
-        plt.savefig(
-            os.path.join(paths.FIGURES_DIR, "%s_hist_%i.png" % (save_plots, gIdx))
+        plt.savefig(save_fname 
         )
     plt.show()
 
@@ -146,7 +141,7 @@ def plotSeabornScatter1(evolution, dfPop=None, save_plots=None, color="C0"):
         plt.savefig(
             os.path.join(
                 paths.FIGURES_DIR,
-                "{}_sns_params_{}.png".format(save_plots, evolution.gIdx),
+                f"{save_plots}_sns_params_{evolution}.png",
             ),
             bbox_inches="tight",
         )

--- a/neurolib/optimize/evolution/evolutionaryUtils.py
+++ b/neurolib/optimize/evolution/evolutionaryUtils.py
@@ -30,7 +30,7 @@ def saveToPypet(traj, pop, gIdx):
             if not np.isnan(p.fitness.values).any() and not p.simulation_stored:
                 pop[i].simulation_stored = True
 
-                traj.f_add_result_group(f"outputs.ind_{p.id:06d}"
+                traj.f_add_result_group(f"outputs.ind_{p.id:06d}")
 
                 assert isinstance(
                     p.outputs, dict
@@ -44,13 +44,9 @@ def saveToPypet(traj, pop, gIdx):
                             traj.f_add_result_group(new_save_string)
                             unpackOutputsAndStore(value, new_save_string)
                         else:
-                            traj.f_add_result(
-                                f"{new_save_string}.{key}", value
-                            )
+                            traj.f_add_result(f"{new_save_string}.{key}", value)
 
-                unpackOutputsAndStore(
-                    p.outputs, save_string=f"outputs.ind_{p.id:06d}"
-                )
+                unpackOutputsAndStore(p.outputs, save_string=f"outputs.ind_{p.id:06d}")
 
         traj.f_store()
     except:
@@ -66,9 +62,7 @@ def printParamDist(pop=None, paramInterval=None, gIdx=None):
     for idx, k in enumerate(paramInterval._fields):
         mean_params = np.mean([indiv[idx] for indiv in pop])
         sdt_params = np.std([indiv[idx] for indiv in pop])
-        print(
-            f"{k}: \t mean: {mean_params:.4f},\t std: {sdt_params:.4f}"
-        )
+        print(f"{k}: \t mean: {mean_params:.4f},\t std: {sdt_params:.4f}")
 
 
 def printIndividuals(pop, paramInterval, stats=True):
@@ -96,13 +90,9 @@ def plotScoresDistribution(scores, gIdx, save_plots=None, color="C0"):
     plt.xlabel("Score")
     plt.ylabel("Count")
     if save_plots is not None:
-        save_fname = os.path.join(paths.FIGURES_DIR, f"{save_plots}_hist_{gIdx}.png"
-        logging.info(
-            f"Saving plot to {save_fname}"
-            )
-        )
-        plt.savefig(save_fname 
-        )
+        save_fname = os.path.join(paths.FIGURES_DIR, f"{save_plots}_hist_{gIdx}.png")
+        logging.info(f"Saving plot to {save_fname}")
+        plt.savefig(save_fname)
     plt.show()
 
 
@@ -140,8 +130,7 @@ def plotSeabornScatter1(evolution, dfPop=None, save_plots=None, color="C0"):
     if save_plots is not None:
         plt.savefig(
             os.path.join(
-                paths.FIGURES_DIR,
-                f"{save_plots}_sns_params_{evolution}.png",
+                paths.FIGURES_DIR, f"{save_plots}_sns_params_{evolution}.png",
             ),
             bbox_inches="tight",
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pandas
 tqdm
 pypet
 deap
+dill

--- a/tests/test_evolution.py
+++ b/tests/test_evolution.py
@@ -106,7 +106,10 @@ class TestALNEvolution(unittest.TestCase):
         evolution.saveEvolution(fname=fname)
         evolution = evolution.loadEvolution(fname)
 
+        # overview of current population
         evolution.dfPop
+        # overview of all past individuals
+        evolution.dfEvolution
 
         end = time.time()
         logging.info("\t > Done in {:.2f} s".format(end - start))
@@ -165,7 +168,10 @@ class TestALNEvolution(unittest.TestCase):
         traj = evolution.loadResults()
         gens, all_scores = evolution.getScoresDuringEvolution()
 
+        # overview of current population
         evolution.dfPop
+        # overview of all past individuals
+        evolution.dfEvolution
 
         end = time.time()
         logging.info("\t > Done in {:.2f} s".format(end - start))

--- a/tests/test_evolution.py
+++ b/tests/test_evolution.py
@@ -68,7 +68,8 @@ class TestALNEvolution(unittest.TestCase):
 
             # example: get dominant frequency of activity
             frs, powers = func.getPowerSpectrum(
-                model.rates_exc[:, -int(1000 / model.params["dt"]) :], model.params["dt"],
+                model.rates_exc[:, -int(1000 / model.params["dt"]) :],
+                model.params["dt"],
             )
             domfr = frs[np.argmax(powers)]
 
@@ -81,11 +82,13 @@ class TestALNEvolution(unittest.TestCase):
         alnModel = ALNModel()
         alnModel.run(bold=True)
 
-        pars = ParameterSpace(["mue_ext_mean", "mui_ext_mean"], [[0.0, 4.0], [0.0, 4.0]])
+        pars = ParameterSpace(
+            ["mue_ext_mean", "mui_ext_mean"], [[0.0, 4.0], [0.0, 4.0]]
+        )
         evolution = Evolution(
             evaluateSimulation,
             pars,
-            algorithm = 'adaptive',
+            algorithm="adaptive",
             model=alnModel,
             weightList=[-1.0],
             POP_INIT_SIZE=4,
@@ -97,6 +100,11 @@ class TestALNEvolution(unittest.TestCase):
         evolution.info(plot=False)
         traj = evolution.loadResults()
         gens, all_scores = evolution.getScoresDuringEvolution()
+
+        # save the evolution and reload it from disk
+        fname = "data/test_saved-evolution.dill"
+        evolution.saveEvolution(fname=fname)
+        evolution = evolution.loadEvolution(fname)
 
         evolution.dfPop
 
@@ -122,7 +130,8 @@ class TestALNEvolution(unittest.TestCase):
 
             # example: get dominant frequency of activity
             frs, powers = func.getPowerSpectrum(
-                model.rates_exc[:, -int(1000 / model.params["dt"]) :], model.params["dt"],
+                model.rates_exc[:, -int(1000 / model.params["dt"]) :],
+                model.params["dt"],
             )
             domfr = frs[np.argmax(powers)]
 
@@ -137,11 +146,13 @@ class TestALNEvolution(unittest.TestCase):
         alnModel = ALNModel()
         alnModel.run(bold=True)
 
-        pars = ParameterSpace(["mue_ext_mean", "mui_ext_mean"], [[0.0, 4.0], [0.0, 4.0]])
+        pars = ParameterSpace(
+            ["mue_ext_mean", "mui_ext_mean"], [[0.0, 4.0], [0.0, 4.0]]
+        )
         evolution = Evolution(
             evaluateSimulation,
             pars,
-            algorithm = 'nsga2',
+            algorithm="nsga2",
             model=alnModel,
             weightList=[-1.0, 1.0],
             POP_INIT_SIZE=4,

--- a/tests/test_evolutionUtils.py
+++ b/tests/test_evolutionUtils.py
@@ -21,7 +21,10 @@ class TestEvolutinUtils(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        pars = ParameterSpace(["mue_ext_mean", "mui_ext_mean", "b"], [[0.0, 3.0], [0.0, 3.0], [0.0, 100.0]])
+        pars = ParameterSpace(
+            ["mue_ext_mean", "mui_ext_mean", "b"],
+            [[0.0, 3.0], [0.0, 3.0], [0.0, 100.0]],
+        )
         evolution = Evolution(
             lambda v: v,
             pars,
@@ -46,6 +49,8 @@ class TestEvolutinUtils(unittest.TestCase):
             p.id = i
             p.fitness.values = fitnessesResult
             p.fitness.score = np.nansum(p.fitness.wvalues) / (len(p.fitness.wvalues))
+            p.gIdx = 0
+
         cls.pop = pop
         cls.evolution.pop = pop
         cls.evolution.gIdx = 1
@@ -61,9 +66,13 @@ class TestEvolutinUtils(unittest.TestCase):
         du.randomParametersAdaptive(self.evolution.paramInterval)
 
     def test_mutateUntilValid(self):
-        du.mutateUntilValid(self.pop, self.evolution.paramInterval, self.evolution.toolbox, maxTries=10)
+        du.mutateUntilValid(
+            self.pop, self.evolution.paramInterval, self.evolution.toolbox, maxTries=10
+        )
 
-    @pytest.mark.skipif(sys.platform == "darwin", reason="plotting does not work on macOS")
+    @pytest.mark.skipif(
+        sys.platform == "darwin", reason="plotting does not work on macOS"
+    )
     def test_plots(self):
         matplotlib = pytest.importorskip("matplotlib")
         eu.plotPopulation(self.evolution, plotScattermatrix=True)
@@ -75,7 +84,9 @@ class TestEvolutionCrossover(unittest.TestCase):
             return (1,), {}
 
         pars = ParameterSpace(["x"], [[0.0, 4.0]])
-        evolution = Evolution(evalFunction=evo, parameterSpace=pars, filename="TestEvolutionCrossover.hdf")
+        evolution = Evolution(
+            evalFunction=evo, parameterSpace=pars, filename="TestEvolutionCrossover.hdf"
+        )
         evolution.runInitial()
         init_pop = evolution.pop.copy()
 


### PR DESCRIPTION
* Load an evolution from disk that was previously saved using `dill`.
Saving:
```python
... # evolution done here
evolution.saveEvolution("data/evolution.dill")
```
Loading, in another session:
```python
# initialize object
evolution = Evolution(lambda x: x, ParameterSpace(['mock'],  [[0, 1]]))
# load from disk
evolution = evolution.loadEvolution("data/evolution.dill")
```

Because the objects are not serializable, I needed to use `dill` for saving and loading. This means, this would be a new dependency (which I' obviously trying to avoid as much as possible). At the same time, saving and loading a previous evolution / exploration is, I think, a very important feature and reinitializing the evolution with the loaded dill is a bit non-trivial, so I thought it makes sense to solve this issue for the user instead of letting them figure it out themselves. I'd be happy about comments on this (@jajcayn?).

* Pandas DataFrame with all individuals from the entire evolution
```python
evolution.dfEvolution
```
Sorry:
Most of the changes are actually black formatting.... :( more coming very soon.

Todo:
* [x] Testing of `saveEvolution()` and `loadEvolution()`
* [ ] Lazy import of dill, is it ok? Should give `ImportError` if import fails
* [x] Docstring dfEvolution