### PR TITLE
evolution: handling of seed = None for pypet

### DIFF
--- a/examples/example-0.3-fhn-minimal.ipynb
+++ b/examples/example-0.3-fhn-minimal.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# The Fitz-Hugh Nagumo oscillator\n",
     "\n",
-    "In this notebook, the basic use of the implementation of the Fitz-Hugh Nagumo (`fhn`) model is presented. Usually, the `fhn` model is used to represent a single neuron (for example in `Cakan et al. (2014)`, \"Heterogeneous delays in neural networks\"). This is due to the difference in timescales of the two equations that define the FHN model: The first equation is often referred to as the \"vast variable\" whereas the second one is the \"slow variable\". This makes it possible to creat a model with a very fast spiking mechanism but with a slow refractory period. \n",
+    "In this notebook, the basic use of the implementation of the Fitz-Hugh Nagumo (`fhn`) model is presented. Usually, the `fhn` model is used to represent a single neuron (for example in `Cakan et al. (2014)`, \"Heterogeneous delays in neural networks\"). This is due to the difference in timescales of the two equations that define the FHN model: The first equation is often referred to as the \"fast variable\" whereas the second one is the \"slow variable\". This makes it possible to create a model with a very fast spiking mechanism but with a slow refractory period. \n",
     "\n",
     "In our case, we are using a parameterization of the `fhn` model that is not quite as usual. Inspired by the paper by `Kostova et al. (2004)` \"FitzHugh–Nagumo revisited: Types of bifurcations, periodical forcing and stability regions by a Lyapunov functional.\", the implementation in `neurolib` produces a slowly oscillating dynamics and has the advantage to incorporate an external input term that causes a Hopf bifurcation. This means, that the model roughly approximates the behaviour of the `aln` model: For low input values, there is a low-activity fixed point, for intermediate inputs, there is an oscillatory region, and for high input values, the system is in a high-activity fixed point. Thus, it offers a simple way of exploring the dynamics of a neural mass model with these properties, such as the `aln` model.\n",
     "\n",
@@ -268,8 +268,8 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
+   "display_name": "Python 3 (Spyder)",
+   "language": "python3",
    "name": "python3"
   },
   "language_info": {
@@ -282,7 +282,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/neurolib/models/aln/loadDefaultParams.py
+++ b/neurolib/models/aln/loadDefaultParams.py
@@ -26,18 +26,15 @@ def loadDefaultParams(Cmat=None, Dmat=None, lookupTableFileName=None, seed=None)
     # recently added for easier simulation of aln and brian in pypet
     params.model = "aln"
     params.name = "aln"
-    params.description = "Adaptive linear-nonlinear model of exponential integrate-and-fire neurons"
+    params.description = (
+        "Adaptive linear-nonlinear model of exponential integrate-and-fire neurons"
+    )
 
     # runtime parameters
     params.dt = 0.1  # ms 0.1ms is reasonable
     params.duration = 2000  # Simulation duration (ms)
     np.random.seed(seed)  # seed for RNG of noise and ICs
-    # set seed to 0 if None, pypet will complain otherwise
-    params.seed = seed or 0
-
-    # make sure that seed=0 remains None
-    if seed == 0:
-        seed = None
+    params.seed = seed
 
     # options
     params.warn = 0  # warn if limits of lookup tables are exceeded
@@ -90,7 +87,9 @@ def loadDefaultParams(Cmat=None, Dmat=None, lookupTableFileName=None, seed=None)
     params.ext_inh_rate = 0.0  # kHz external inhibiroty rate drive
 
     # externaln input currents, same as mue_ext_mean but can be time-dependent!
-    params.ext_exc_current = 0.0  # external excitatory input current [mV/ms], C*[]V/s=[]nA
+    params.ext_exc_current = (
+        0.0  # external excitatory input current [mV/ms], C*[]V/s=[]nA
+    )
     params.ext_inh_current = 0.0  # external inhibiroty input current [mV/ms]
 
     # Fokker Planck noise (for N->inf)
@@ -176,7 +175,9 @@ def loadDefaultParams(Cmat=None, Dmat=None, lookupTableFileName=None, seed=None)
 
     # load precomputed aLN transfer functions from hdfs
     if lookupTableFileName is None:
-        lookupTableFileName = os.path.join(os.path.dirname(__file__), "aln-precalc", "quantities_cascade.h5")
+        lookupTableFileName = os.path.join(
+            os.path.dirname(__file__), "aln-precalc", "quantities_cascade.h5"
+        )
 
     hf = h5py.File(lookupTableFileName, "r")
     params.Irange = hf.get("mu_vals")[()]

--- a/neurolib/models/fhn/loadDefaultParams.py
+++ b/neurolib/models/fhn/loadDefaultParams.py
@@ -23,12 +23,7 @@ def loadDefaultParams(Cmat=None, Dmat=None, seed=None):
     params.dt = 0.1  # ms 0.1ms is reasonable
     params.duration = 2000  # Simulation duration (ms)
     np.random.seed(seed)  # seed for RNG of noise and ICs
-    # set seed to 0 if None, pypet will complain otherwise
-    params.seed = seed or 0
-
-    # make sure that seed=0 remains None
-    if seed == 0:
-        seed = None
+    params.seed = seed
 
     # ------------------------------------------------------------------------
     # global whole-brain network parameters

--- a/neurolib/models/thalamus/loadDefaultParams.py
+++ b/neurolib/models/thalamus/loadDefaultParams.py
@@ -18,12 +18,7 @@ def loadDefaultParams(seed=None):
     params.dt = 0.01  # ms
     params.duration = 60000  # Simulation duration (ms)
     np.random.seed(seed)  # seed for RNG of noise and ICs
-    # set seed to 0 if None, pypet will complain otherwise
-    params.seed = seed or 0
-
-    # make sure that seed=0 remains None
-    if seed == 0:
-        seed = None
+    params.seed = seed
 
     # local parameters for both populations
     params.tau = 20.0

--- a/neurolib/models/wc/loadDefaultParams.py
+++ b/neurolib/models/wc/loadDefaultParams.py
@@ -23,12 +23,7 @@ def loadDefaultParams(Cmat=None, Dmat=None, seed=None):
     params.dt = 0.1  # ms 0.1ms is reasonable
     params.duration = 2000  # Simulation duration (ms)
     np.random.seed(seed)  # seed for RNG of noise and ICs
-    # set seed to 0 if None, pypet will complain otherwise
-    params.seed = seed or 0
-
-    # make sure that seed=0 remains None
-    if seed == 0:
-        seed = None
+    params.seed = seed
 
     # ------------------------------------------------------------------------
     # global whole-brain network parameters

--- a/neurolib/optimize/evolution/evolution.py
+++ b/neurolib/optimize/evolution/evolution.py
@@ -897,6 +897,11 @@ class Evolution:
         dfEvolution["id"] = indIds
         dfEvolution["gen"] = [p.gIdx for p in allIndividuals]
 
+        # the history keeps all individuals of all generations
+        # there can be duplicates (in elitism for example), which we filter
+        # out for the dataframe
+        dfEvolution = dfEvolution.drop_duplicates()
+
         # add fitness columns
         # NOTE: have to do this with wvalues and divide by weights later, why?
         # Because after loading the evolution with dill, somehow multiple fitnesses

--- a/neurolib/optimize/evolution/evolution.py
+++ b/neurolib/optimize/evolution/evolution.py
@@ -93,10 +93,14 @@ class Evolution:
         """
 
         if weightList is None:
-            logging.info("weightList not set, assuming single fitness value to be maximized.")
+            logging.info(
+                "weightList not set, assuming single fitness value to be maximized."
+            )
             weightList = [1.0]
 
-        trajectoryName = "results" + datetime.datetime.now().strftime("-%Y-%m-%d-%HH-%MM-%SS")
+        trajectoryName = "results" + datetime.datetime.now().strftime(
+            "-%Y-%m-%d-%HH-%MM-%SS"
+        )
         logging.info(f"Trajectory Name: {trajectoryName}")
         self.HDF_FILE = os.path.join(paths.HDF_DIR, filename)
         trajectoryFileName = self.HDF_FILE
@@ -190,22 +194,40 @@ class Evolution:
             self.individualGenerator = du.randomParameters
 
         else:
-            raise ValueError("Evolution: algorithm must be one of the following: ['adaptive', 'nsga2']")
+            raise ValueError(
+                "Evolution: algorithm must be one of the following: ['adaptive', 'nsga2']"
+            )
 
         # if the operators are set manually, then overwrite them
-        self.matingOperator = self.matingOperator if hasattr(self, "matingOperator") else matingOperator
-        self.mutationOperator = self.mutationOperator if hasattr(self, "mutationOperator") else mutationOperator
-        self.selectionOperator = self.selectionOperator if hasattr(self, "selectionOperator") else selectionOperator
+        self.matingOperator = (
+            self.matingOperator if hasattr(self, "matingOperator") else matingOperator
+        )
+        self.mutationOperator = (
+            self.mutationOperator
+            if hasattr(self, "mutationOperator")
+            else mutationOperator
+        )
+        self.selectionOperator = (
+            self.selectionOperator
+            if hasattr(self, "selectionOperator")
+            else selectionOperator
+        )
         self.parentSelectionOperator = (
-            self.parentSelectionOperator if hasattr(self, "parentSelectionOperator") else parentSelectionOperator
+            self.parentSelectionOperator
+            if hasattr(self, "parentSelectionOperator")
+            else parentSelectionOperator
         )
         self.individualGenerator = (
-            self.individualGenerator if hasattr(self, "individualGenerator") else individualGenerator
+            self.individualGenerator
+            if hasattr(self, "individualGenerator")
+            else individualGenerator
         )
 
         # let's also make sure that the parameters are set correctly
         self.MATE_P = self.MATE_P if hasattr(self, "MATE_P") else {}
-        self.PARENT_SELECT_P = self.PARENT_SELECT_P if hasattr(self, "PARENT_SELECT_P") else {}
+        self.PARENT_SELECT_P = (
+            self.PARENT_SELECT_P if hasattr(self, "PARENT_SELECT_P") else {}
+        )
         self.MUTATE_P = self.MUTATE_P if hasattr(self, "MUTATE_P") else {}
         self.SELECT_P = self.SELECT_P if hasattr(self, "SELECT_P") else {}
 
@@ -290,7 +312,11 @@ class Evolution:
         :return: Parameter dictionary of this individual
         :rtype: dict
         """
-        return self.ParametersInterval(*(individual[: len(self.paramInterval)]))._asdict().copy()
+        return (
+            self.ParametersInterval(*(individual[: len(self.paramInterval)]))
+            ._asdict()
+            .copy()
+        )
 
     def initPypetTrajectory(self, traj, paramInterval, POP_SIZE, NGEN, model):
         """Initializes pypet trajectory and store all simulation parameters for later analysis.
@@ -315,8 +341,12 @@ class Evolution:
         # Placeholders for individuals and results that are about to be explored
         traj.f_add_parameter("generation", 0, comment="Current generation")
 
-        traj.f_add_result("scores", [], comment="Score of all individuals for each generation")
-        traj.f_add_result_group("evolution", comment="Contains results for each generation")
+        traj.f_add_result(
+            "scores", [], comment="Score of all individuals for each generation"
+        )
+        traj.f_add_result_group(
+            "evolution", comment="Contains results for each generation"
+        )
         traj.f_add_result_group("outputs", comment="Contains simulation results")
 
         # TODO: save evolution parameters and operators as well, MATE_P, MUTATE_P, etc..
@@ -324,13 +354,20 @@ class Evolution:
         # if a model was given, save its parameters
         # NOTE: Convert model.params to dict() since it is a dotdict() and pypet doesn't like that
         if model is not None:
-            traj.f_add_result("params", dict(model.params), comment="Default parameters")
+            params_dict = dict(model.params)
+            # replace all None with zeros, pypet doesn't like None
+            for key, value in params_dict.items():
+                if value is None:
+                    params_dict[key] = 0
+            traj.f_add_result("params", params_dict, comment="Default parameters")
 
         # todo: initialize this after individuals have been defined!
         traj.f_add_parameter("id", 0, comment="Index of individual")
         traj.f_add_parameter("ind_len", 20, comment="Length of individual")
         traj.f_add_derived_parameter(
-            "individual", [0 for x in range(traj.ind_len)], "An indivudal of the population",
+            "individual",
+            [0 for x in range(traj.ind_len)],
+            "An indivudal of the population",
         )
 
     def initDEAP(
@@ -365,14 +402,19 @@ class Evolution:
         :param individualGenerator: Function that generates individuals
         """
         # ------------- register everything in deap
-        deap.creator.create("FitnessMulti", deap.base.Fitness, weights=tuple(weightList))
+        deap.creator.create(
+            "FitnessMulti", deap.base.Fitness, weights=tuple(weightList)
+        )
         deap.creator.create("Individual", list, fitness=deap.creator.FitnessMulti)
 
         # initially, each individual has randomized genes
         # need to create a lambda funciton because du.generateRandomParams wants an argument but
         # toolbox.register cannot pass an argument to it.
         toolbox.register(
-            "individual", deap.tools.initIterate, deap.creator.Individual, lambda: individualGenerator(paramInterval),
+            "individual",
+            deap.tools.initIterate,
+            deap.creator.Individual,
+            lambda: individualGenerator(paramInterval),
         )
         logging.info(f"Evolution: Individual generation: {individualGenerator}")
 
@@ -462,9 +504,9 @@ class Evolution:
             pop[idx].fitness.values = fitnessesResult
 
             # compute score
-            pop[idx].fitness.score = np.ma.masked_invalid(pop[idx].fitness.wvalues).sum() / (
-                len(pop[idx].fitness.wvalues)
-            )
+            pop[idx].fitness.score = np.ma.masked_invalid(
+                pop[idx].fitness.wvalues
+            ).sum() / (len(pop[idx].fitness.wvalues))
         return pop
 
     def getValidPopulation(self, pop=None):
@@ -476,7 +518,13 @@ class Evolution:
         :rtype: list
         """
         pop = pop or self.pop
-        return [p for p in pop if not (np.isnan(p.fitness.values).any() or np.isinf(p.fitness.values).any())]
+        return [
+            p
+            for p in pop
+            if not (
+                np.isnan(p.fitness.values).any() or np.isinf(p.fitness.values).any()
+            )
+        ]
 
     def getInvalidPopulation(self, pop=None):
         """Returns a list of the invalid population.
@@ -487,7 +535,11 @@ class Evolution:
         :rtype: list
         """
         pop = pop or self.pop
-        return [p for p in pop if np.isnan(p.fitness.values).any() or np.isinf(p.fitness.values).any()]
+        return [
+            p
+            for p in pop
+            if np.isnan(p.fitness.values).any() or np.isinf(p.fitness.values).any()
+        ]
 
     def tagPopulation(self, pop):
         """Take a fresh population and add id's and attributes such as parameters that we can use later
@@ -498,7 +550,9 @@ class Evolution:
         :rtype: list
         """
         for i, ind in enumerate(pop):
-            assert not hasattr(ind, "id"), "Individual has an id already, will not overwrite it!"
+            assert not hasattr(
+                ind, "id"
+            ), "Individual has an id already, will not overwrite it!"
             ind.id = self.last_id
             ind.gIdx = self.gIdx
             ind.simulation_stored = False
@@ -526,7 +580,9 @@ class Evolution:
         self.pop = self.tagPopulation(self.pop)
 
         # evaluate
-        self.pop = self.evalPopulationUsingPypet(self.traj, self.toolbox, self.pop, self.gIdx)
+        self.pop = self.evalPopulationUsingPypet(
+            self.traj, self.toolbox, self.pop, self.gIdx
+        )
 
         if self.verbose:
             eu.printParamDist(self.pop, self.paramInterval, self.gIdx)
@@ -563,12 +619,19 @@ class Evolution:
             # ------- Create the next generation by crossover and mutation -------- #
             ### Select parents using rank selection and clone them ###
             offspring = list(
-                map(self.toolbox.clone, self.toolbox.selectParents(self.pop, self.POP_SIZE, **self.PARENT_SELECT_P),)
+                map(
+                    self.toolbox.clone,
+                    self.toolbox.selectParents(
+                        self.pop, self.POP_SIZE, **self.PARENT_SELECT_P
+                    ),
+                )
             )
 
             ##### cross-over ####
             for i in range(1, len(offspring), 2):
-                offspring[i - 1], offspring[i] = self.toolbox.mate(offspring[i - 1], offspring[i], **self.MATE_P)
+                offspring[i - 1], offspring[i] = self.toolbox.mate(
+                    offspring[i - 1], offspring[i], **self.MATE_P
+                )
                 # delete fitness inherited from parents
                 del offspring[i - 1].fitness.values, offspring[i].fitness.values
                 del offspring[i - 1].fitness.wvalues, offspring[i].fitness.wvalues
@@ -583,22 +646,30 @@ class Evolution:
 
             ##### Mutation ####
             # Apply mutation
-            du.mutateUntilValid(offspring, self.paramInterval, self.toolbox, MUTATE_P=self.MUTATE_P)
+            du.mutateUntilValid(
+                offspring, self.paramInterval, self.toolbox, MUTATE_P=self.MUTATE_P
+            )
 
             offspring = self.tagPopulation(offspring)
 
             # ------- Evaluate next generation -------- #
 
             self.pop = offspring + newpop
-            self.evalPopulationUsingPypet(self.traj, self.toolbox, offspring + newpop, self.gIdx)
+            self.evalPopulationUsingPypet(
+                self.traj, self.toolbox, offspring + newpop, self.gIdx
+            )
 
             # log individuals
-            self.history[self.gIdx] = validpop + offspring + newpop  # self.getValidPopulation(self.pop)
+            self.history[self.gIdx] = (
+                validpop + offspring + newpop
+            )  # self.getValidPopulation(self.pop)
 
             # ------- Select surviving population -------- #
 
             # select next generation
-            self.pop = self.toolbox.select(validpop + offspring + newpop, k=self.traj.popsize, **self.SELECT_P)
+            self.pop = self.toolbox.select(
+                validpop + offspring + newpop, k=self.traj.popsize, **self.SELECT_P
+            )
 
             # ------- END OF ROUND -------
 
@@ -621,7 +692,9 @@ class Evolution:
                 self.info(plot=True, info=True)
 
         logging.info("--- End of evolution ---")
-        logging.info("Best individual is %s, %s" % (self.best_ind, self.best_ind.fitness.values))
+        logging.info(
+            "Best individual is %s, %s" % (self.best_ind, self.best_ind.fitness.values)
+        )
         logging.info("--- End of evolution ---")
 
         self.traj.f_store()  # We switched off automatic storing, so we need to store manually
@@ -685,9 +758,14 @@ class Evolution:
             try:
                 self.plotProgress(reverse=reverse)
             except:
-                logging.warn("Could not plot progress, is this a previously saved simulation?")
+                logging.warn(
+                    "Could not plot progress, is this a previously saved simulation?"
+                )
             eu.plotPopulation(
-                self, plotScattermatrix=True, save_plots=self.trajectoryName, color=self.plotColor,
+                self,
+                plotScattermatrix=True,
+                save_plots=self.trajectoryName,
+                color=self.plotColor,
             )
 
     def plotProgress(self, reverse=False):
@@ -703,7 +781,9 @@ class Evolution:
         """
         import dill
 
-        fname = fname or os.path.join("data/", "evolution-" + self.trajectoryName + ".dill")
+        fname = fname or os.path.join(
+            "data/", "evolution-" + self.trajectoryName + ".dill"
+        )
         dill.dump(self, open(fname, "wb"))
         logging.info(f"Saving evolution to {fname}")
 
@@ -733,7 +813,10 @@ class Evolution:
         # the parameter space in the dill
         from neurolib.utils.parameterSpace import ParameterSpace
 
-        pars = ParameterSpace(evolution.parameterSpace.parameterNames, evolution.parameterSpace.parameterValues,)
+        pars = ParameterSpace(
+            evolution.parameterSpace.parameterNames,
+            evolution.parameterSpace.parameterValues,
+        )
 
         evolution.parameterSpace = pars
         evolution.paramInterval = evolution.parameterSpace.named_tuple
@@ -770,7 +853,9 @@ class Evolution:
         # add the current population to the dataframe
         validPop = self.getValidPopulation(self.pop)
         indIds = [p.id for p in validPop]
-        popArray = np.array([p[0 : len(self.paramInterval._fields)] for p in validPop]).T
+        popArray = np.array(
+            [p[0 : len(self.paramInterval._fields)] for p in validPop]
+        ).T
 
         dfPop = pd.DataFrame(popArray, index=self.parameterSpace.parameterNames).T
 
@@ -801,7 +886,9 @@ class Evolution:
         """
         parameters = self.parameterSpace.parameterNames
         allIndividuals = [p for gen, pop in self.history.items() for p in pop]
-        popArray = np.array([p[0 : len(self.paramInterval._fields)] for p in allIndividuals]).T
+        popArray = np.array(
+            [p[0 : len(self.paramInterval._fields)] for p in allIndividuals]
+        ).T
         dfEvolution = pd.DataFrame(popArray, index=parameters).T
         # add more information to the dataframe
         scores = [float(p.fitness.score) for p in allIndividuals]

--- a/neurolib/optimize/evolution/evolution.py
+++ b/neurolib/optimize/evolution/evolution.py
@@ -358,7 +358,7 @@ class Evolution:
             # replace all None with zeros, pypet doesn't like None
             for key, value in params_dict.items():
                 if value is None:
-                    params_dict[key] = 0
+                    params_dict[key] = "None"
             traj.f_add_result("params", params_dict, comment="Default parameters")
 
         # todo: initialize this after individuals have been defined!

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("requirements.txt") as f:
 
 setuptools.setup(
     name="neurolib",
-    version="0.5.4",
+    version="0.5.5",
     description="Easy whole-brain neural mass modeling",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
`pypet` doesn't like to add `None` results. The RNG seed parameter `model.params["seed"]` is usually `None` and was set to `0` to avoid issues before. Now it stays `None` but when saving to `pypet`, the case is handled.

The rest of the other changes are only black formatting...