### PR TITLE
MultiModel PR 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,18 +34,22 @@ jobs:
       language: sh
       addons:
         homebrew:
-          update: false
-          packages: python3
+          update: true
+          packages:
+            - python3
+            - llvm
+            - libomp
       before_install:
-        - pip install virtualenv
+        - brew link --overwrite python
+        - export PATH=/usr/local/opt/llvm/bin:$PATH
+        - pip3 install virtualenv
         - virtualenv -p python3 ~/venv
         - source ~/venv/bin/activate
-        
     # - stage: test
     #   os: windows
     #   language: sh
     #   env:
     #     - PATH="/c/Python37:/c/Python37/Scripts:$PATH"
-    #   before_install: 
+    #   before_install:
     #     - choco install python --version 3.7.3
     #     - python -m pip install --upgrade pip

--- a/neurolib/models/multimodel/__init__.py
+++ b/neurolib/models/multimodel/__init__.py
@@ -1,0 +1,1 @@
+from .model import MultiModel

--- a/neurolib/models/multimodel/__init__.py
+++ b/neurolib/models/multimodel/__init__.py
@@ -1,1 +1,0 @@
-from .model import MultiModel

--- a/neurolib/models/multimodel/builder/base/backend.py
+++ b/neurolib/models/multimodel/builder/base/backend.py
@@ -1,0 +1,590 @@
+"""
+Backend integrator and backends definitions. Currently supported are following
+backends:
+ - `jitcdde`: (just-in-time compilation into C) which exploits `jitcdde` library
+    and translates symbolic derivatives into C code and then calls C functions
+    from python interface:
+    - very reliable
+    - uses adaptive `dt` hence very useful for stiff problems and when you are
+        not sure how stiff your model is
+    - reasonable speed
+
+ - `numba`: compilation of python code through `numba.njit()` - symbolic
+    derivatives are handled to string and then rendered to prepared numba
+    function template and compiled to python;
+    - less reliable
+    - need to define integration step, `dt`
+    - uses basic Euler scheme
+    - very fast -> almost agnostic to duration of the simulation, i.e. good for
+        very long simulations
+"""
+import json
+import logging
+import os
+import pickle
+import re
+import time
+from copy import deepcopy
+from functools import wraps
+from sys import platform
+from types import FunctionType
+
+import numba
+import numpy as np
+import symengine as se
+import xarray as xr
+from chspy import CubicHermiteSpline
+from jitcdde import jitcdde_input
+from numpy import *  # noqa: F403,F401
+from tqdm import tqdm
+
+DEFAULT_BACKEND = "jitcdde"
+
+
+def timer(method):
+    """
+    Decorator for timing functions. Writes the time to logger.
+    """
+
+    @wraps(method)
+    def decorator(*args, **kwargs):
+        time_start = time.time()
+        result = method(*args, **kwargs)
+        logging.info(f"`{method.__name__}` call took {time.time() - time_start:.2f} s")
+        return result
+
+    return decorator
+
+
+class BaseBackend:
+    """
+    Base class for backends.
+    """
+
+    _derivatives = None
+    _sync = None
+    _callbacks = None
+    initial_state = None
+    num_state_variables = None
+    max_delay = None
+    state_variable_names = None
+    label = None
+
+    def run(self):
+        raise NotImplementedError
+
+    def clean(self):
+        pass
+
+
+class NumbaBackend(BaseBackend):
+    """
+    Backend using manual basic Euler scheme with delays. The symbolic code for
+    derivatives is rendered into prepared string template using numba's njit to
+    speed up the computation.
+    """
+
+    DEFAULT_DT = 0.1  # in ms
+
+    CURRENT_Y_REGEX = r"current_y\([0-9]*\)"
+    CURRENT_Y_NUMBA = "y[max_delay + i - 1, {idx}]"
+
+    PAST_Y_REGEX = r"past_y\([-+]?[0-9]*\.?[0-9]+ \+ t, [0-9]*, anchors\([-+]" r"?[0-9]*\.?[0-9]+ \+ t\)\)"
+    PAST_Y_NUMBA = "y[max_delay + i - 1 - {dt_ndt}, {idx}]"
+
+    SYSTEM_INPUT_REGEX = (
+        r"past_y\(-external_input \+ t, ([0-9]* \+ )?input_base_n, anchors" r"\(-external_input \+ t\)\)"
+    )
+    SYSTEM_INPUT_NUMBA = "input_y[i, {idx}]"
+
+    NUMBA_STRING_TEMPLATE = """
+def integrate(dt, n, max_delay, t_max, y0, input_y):
+    y = np.empty((t_max + max_delay + 1, n))
+    y[:] = np.nan
+    y[:max_delay + 1] = y0
+    for i in range(1, t_max + 1):
+        dy = np.array({dy_eqs})
+        y[max_delay + i, :] = y[max_delay + i - 1, :] + dt*dy
+
+    return y[max_delay + 1:, :]
+"""
+
+    def _replace_current_ys(self, expression):
+        """
+        Replace `current_y` symbolic representation of current state of the
+        state vector with numpy array. Assume output in as `y[time, space]`.
+
+        :param expression: string expression to look in for symbolic symbols
+        :type expression: str
+        :return: expression with replaced symblic values to numpy array
+        :rtype: str
+        """
+        matches = re.findall(self.CURRENT_Y_REGEX, expression)
+        for match in matches:
+            idx = match[10:-1]
+            replace_with = self.CURRENT_Y_NUMBA.format(idx=idx)
+            expression = expression.replace(match, replace_with)
+        return expression
+
+    def _replace_past_ys(self, expression, dt):
+        """
+        Replace `past_y` symbolic representation of past state of the state
+        vector with numpy array. Assume output in as `y[time, space]`.
+
+        :param expression: string expression to look in for symbolic symbols
+        :type expression: str
+        :param dt: dt for the integration
+        :type dt: float
+        :return: expression with replaced symblic values to numpy array
+        :rtype: str
+        """
+        matches = re.findall(self.PAST_Y_REGEX, expression)
+        for match in matches:
+            time_past, idx, _ = match.split(",")
+            idx = int(idx)
+            t_past = float(time_past.split("+")[0].strip()[7:])
+            t_past_ndx = np.around(t_past / dt).astype(int)
+            replace_with = self.PAST_Y_NUMBA.format(dt_ndt=np.abs(t_past_ndx), idx=idx)
+            expression = expression.replace(match, replace_with)
+        return expression
+
+    def _replace_inputs(self, expression):
+        """
+        Replace `system_input` (usually noise and/or external stimulus) symbolic
+        representation with numpy array of inputs. Assume input as
+        `input[time,index]`.
+
+        :param expression: string expression to look in for symbolic symbols
+        :type expression: str
+        :return: expression with replaced symblic values to numpy array
+        :rtype: str
+        """
+        matches = re.findall(self.SYSTEM_INPUT_REGEX, expression)
+        matches = [match if len(match) > 0 else None for match in matches]
+        splits = re.split(self.SYSTEM_INPUT_REGEX, expression)
+        return_string = []
+        for split in splits:
+            if split in matches:
+                if split is None:
+                    return_string.append(self.SYSTEM_INPUT_NUMBA.format(idx=0))
+                else:
+                    return_string.append(self.SYSTEM_INPUT_NUMBA.format(idx=split[:-3]))
+            else:
+                return_string.append(split)
+        return "".join(return_string)
+
+    def _substitute_helpers(self, derivatives, helpers):
+        """
+        Substitute helpers (usually used for coupling) to derivatives.
+
+        :param derivatives: list of symbolic expressions for derivatives
+        :type derivatives: list
+        :param helpers: list of tuples as (helper name, symbolic expression) for
+            helpers
+        :type helpers: list[tuple]
+        """
+        sympified_helpers = [(se.sympify(helper[0]), se.sympify(helper[1])) for helper in helpers]
+        sympified_derivatives = [se.sympify(derivative) for derivative in derivatives]
+        substitutions = {helper[0]: helper[1] for helper in sympified_helpers}
+        return [derivative.subs(substitutions) for derivative in sympified_derivatives]
+
+    def run(self, duration, sampling_dt, noise_input, time_spin_up=0.0, **kwargs):
+        """
+        Run integration.
+
+        :kwargs:
+            - dt: dt for the Euler integration
+        """
+        assert isinstance(noise_input, np.ndarray)
+        dt = kwargs.pop("dt", self.DEFAULT_DT)
+        system_size = len(self._derivatives())
+
+        # substitute helpers to symbolic derivatives
+        logging.info("Substituting helpers...")
+        substituted = self._substitute_helpers(derivatives=self._derivatives(), helpers=self._sync())
+        assert len(substituted) == system_size
+
+        # replace symbolic expressions with numpy ones
+        logging.info("Replacing symbolic expressions with arrays...")
+        derivatives_str = self._replace_inputs(str(substituted))
+        derivatives_str = self._replace_current_ys(derivatives_str)
+        derivatives_str = self._replace_past_ys(derivatives_str, dt=dt)
+        assert isinstance(derivatives_str, str)
+        logging.info("Compiling python code using numba's njit...")
+        numba_func = self.NUMBA_STRING_TEMPLATE.format(dt=dt, dy_eqs=derivatives_str)
+        # compile numba function and load into namespace
+        numba_code = compile(numba_func, "<string>", "exec")
+        integrate = numba.njit(
+            FunctionType(
+                numba_code.co_consts[-3],
+                {
+                    **globals(),
+                    # add numba callbacks to the mix
+                    **{name: definition for name, definition in self._numba_callbacks()},
+                },
+                name="integrate",
+                argdefs=(),
+            )
+        )
+        assert callable(integrate)
+        # run the numba-jitted function
+        times = time_spin_up + np.arange(sampling_dt, duration + sampling_dt, sampling_dt)
+        logging.info(f"Integrating for {times.shape[0]} time steps...")
+        result = integrate(
+            dt=dt,
+            n=system_size,
+            max_delay=np.around(self.max_delay / dt).astype(int),
+            t_max=np.around((duration + time_spin_up) / dt).astype(int),
+            y0=self.initial_state,
+            input_y=noise_input,
+        )
+        times_integrator = np.arange(dt, time_spin_up + duration + dt, dt)
+        # get indices for subsampling
+        _, subsampling_idx, _ = np.intersect1d(
+            np.around(times_integrator, decimals=5), np.around(times, decimals=5), return_indices=True,
+        )
+        np.testing.assert_allclose(times_integrator[subsampling_idx], times)
+        return times, result[subsampling_idx, :]
+
+
+class JitcddeBackend(BaseBackend):
+    """
+    Backend using jitcdde integrator. Uses just-in-time compilation for delay
+    differential equations with integration method proposed by Shampine and
+    Thompson.
+
+    Reference (package):
+        Ansmann, G. (2018). Efficiently and easily integrating differential
+        equations with JiTCODE, JiTCDDE, and JiTCSDE. Chaos: An
+        Interdisciplinary Journal of Nonlinear Science, 28(4), 043116.
+
+    Reference (method):
+        Shampine, L. F., & Thompson, S. (2001). Solving DDEs in matlab. Applied
+        Numerical Mathematics, 37(4), 441-458.
+    """
+
+    extra_compile_args = []
+    dde_system = None
+
+    def _init_load_compiled(
+        self, compiled_dir, derivatives, helpers=None, inputs=None, max_delay=0.0, callbacks=None,
+    ):
+        """
+        Initialise DDE system and load from compiled.
+        """
+        logging.info("Setting up the DDE system...")
+        compiled_filename = os.path.join(compiled_dir, f"{self.label}.so")
+        assert os.path.exists(compiled_filename)
+        self.dde_system = jitcdde_input(
+            f_sym=derivatives,
+            input=inputs,
+            helpers=helpers,
+            n=len(derivatives),
+            max_delay=max_delay,
+            callback_functions=callbacks,
+            module_location=compiled_filename,
+        )
+
+    def _init_and_compile_C(
+        self, derivatives, helpers=None, inputs=None, max_delay=0.0, callbacks=None, chunksize=1, use_open_mp=False,
+    ):
+        """
+        Initialise DDE system and compiled to C.
+        """
+        logging.info("Setting up the DDE system...")
+        if platform == "darwin":
+            # assert clang is used on macOS
+            os.environ["CC"] = "clang"
+        callbacks = callbacks or ()
+        self.dde_system = jitcdde_input(
+            f_sym=derivatives,
+            input=inputs,
+            helpers=helpers,
+            n=len(derivatives),
+            max_delay=max_delay,
+            callback_functions=callbacks,
+        )
+        if use_open_mp:
+            logging.info("Using OpenMP parallelisation...")
+            compiler_args = ["-fopenmp"]
+            if platform == "darwin":
+                logging.warning(
+                    "MacOS detected. For openMP parallelisation the llvm and "
+                    "libomp must be installed. If not, install them please "
+                    "with `brew install llvm libomp` and follow steps for "
+                    "prepending system path with llvm path."
+                )
+                linker_args = ["-lomp", "-L/usr/local/opt/llvm/lib"]
+            else:
+                linker_args = ["-lgomp"]
+            omp_flags = (compiler_args, linker_args)
+        else:
+            omp_flags = False
+
+        logging.info("Compiling to C...")
+        self.dde_system.compile_C(
+            simplify=False,
+            do_cse=False,
+            extra_compile_args=self.extra_compile_args,
+            omp=omp_flags,
+            chunk_size=chunksize,
+            verbose=False,
+        )
+
+    def _set_constant_past(self, past_state):
+        self.dde_system.constant_past(past_state)
+        self.dde_system.adjust_diff()
+
+    def _integrate_blindly(self, max_delay):
+        self.dde_system.integrate_blindly(max_delay * 1.5)
+
+    def _check(self):
+        if self.dde_system is not None:
+            self.dde_system.check()
+
+    def run(
+        self, duration, sampling_dt, noise_input, time_spin_up=0.0, **kwargs,
+    ):
+        """
+        Run integration.
+
+        :kwargs:
+            - use_open_mp: OpenMP parallelization - significant overhead, only
+                useful (probably) for very large systems
+            - save_compiled_to: path to which save compiled C code -
+                derivatives and helpers; for large networks this saves the
+                compilation time given multiple runs
+            - load_compiled: whether to try load compiled C code, i.e. do not
+            compile before the run
+        """
+        chunksize = kwargs.pop("chunksize", 1)
+        use_open_mp = kwargs.pop("use_open_mp", False)
+        save_compiled_to = kwargs.pop("save_compiled_to", None)
+        load_compiled = kwargs.pop("load_compiled", False)
+        assert isinstance(noise_input, CubicHermiteSpline)
+
+        if load_compiled:
+            self._init_load_compiled(
+                compiled_dir=save_compiled_to,
+                derivatives=self._derivatives(),
+                helpers=self._sync(),
+                inputs=noise_input,
+                max_delay=self.max_delay,
+                callbacks=self._callbacks(),
+            )
+        else:
+            self._init_and_compile_C(
+                derivatives=self._derivatives(),
+                helpers=self._sync(),
+                inputs=noise_input,
+                max_delay=self.max_delay,
+                callbacks=self._callbacks(),
+                chunksize=chunksize,
+                use_open_mp=use_open_mp,
+            )
+        assert self.dde_system is not None
+        self.dde_system.reset_integrator()
+        logging.info("Setting past of the state vector...")
+        self._set_constant_past(self.initial_state)
+        # integrate
+        times = time_spin_up + np.arange(sampling_dt, duration + sampling_dt, sampling_dt)
+        logging.info(f"Integrating for {times.shape[0]} time steps...")
+        result = np.vstack([self.dde_system.integrate(time) for time in tqdm(times)])
+        if save_compiled_to is not None and not load_compiled:
+            os.makedirs(save_compiled_to, exist_ok=True)
+            logging.info(f"Saving compiled C code to {save_compiled_to}")
+            self.dde_system.save_compiled(
+                os.path.join(save_compiled_to, f"{self.label}.so"), overwrite=True,
+            )
+        return times, result
+
+    def clean(self):
+        """
+        Clean - i.e. remove temp directory from C compilation.
+        """
+        self.dde_system.__del__()
+
+
+class BackendIntegrator:
+    """
+    Backend integrator mixin - implements integration using various backends,
+    stores results in xarray and is able to save xr.Datasets to pickle or
+    netCDF.
+    """
+
+    backend_instance = None
+
+    # these attributes are need for successful integrator run
+    NEEDED_ATTRIBUTES = [
+        "_derivatives",
+        "_sync",
+        "_callbacks",
+        "_numba_callbacks",
+        "initial_state",
+        "num_state_variables",
+        "max_delay",
+        "state_variable_names",
+        "label",
+        "initialised",
+    ]
+
+    def _init_backend(self, backend):
+        if backend == "jitcdde":
+            self.backend_instance = JitcddeBackend()
+        elif backend == "numba":
+            self.backend_instance = NumbaBackend()
+        else:
+            raise ValueError(f"Unknown backend: {backend}")
+        # copy necessary attributes (i.e. symbolic derivatives, helpers, etc) to
+        # backend instance
+        for attr in self.NEEDED_ATTRIBUTES:
+            setattr(self.backend_instance, attr, getattr(self, attr))
+
+    @timer
+    def run(
+        self, duration, sampling_dt, noise_input, time_spin_up=0.0, metadata=None, backend=DEFAULT_BACKEND, **kwargs,
+    ):
+        """
+        Run the integration.
+
+        :param duration: duration of the run, in ms
+        :type duration: float
+        :param sampling_dt: sampling dt, in ms
+        :type sampling_dt: float
+        :param noise_input: noise input to the network or node
+        :type noise_input: `chspy.CubicHermiteSpline`|np.ndarray
+        :param time_spin_up: time for model spinup - will be thrown away, in ms
+        :type time_spin_up: float
+        :param metadata: optional metadata as dict
+        :type metadata: dict|None
+        :*kwargs: optional keyword arguments, will be passed to backend instance
+        """
+        assert all(hasattr(self, attr) for attr in self.NEEDED_ATTRIBUTES)
+        assert self.initialised, "Model must be initialised"
+        assert isinstance(noise_input, (CubicHermiteSpline, np.ndarray))
+
+        logging.info(f"Initialising {backend} backend...")
+        self._init_backend(backend)
+        assert isinstance(self.backend_instance, BaseBackend)
+        times, result = self.backend_instance.run(
+            duration=duration, sampling_dt=sampling_dt, noise_input=noise_input, time_spin_up=time_spin_up, **kwargs,
+        )
+        logging.info("Integration done.")
+        assert times.shape[0] == result.shape[0]
+        assert result.shape[1] == self.num_state_variables
+        return self._init_xarray(times=times, results=result, attributes=metadata,)
+
+    def _init_xarray(self, times, results, attributes=None):
+        """
+        Initialise results array.
+
+        :param times: time for the result, in ms
+        :type times: np.ndarray
+        :param results: results as times x state variable
+        :type results: np.ndarray
+        :param attributes: optional description attributes to add to xr.Dataset
+        :type attributes: dict|None
+        """
+        assert times.shape[0] == results.shape[0]
+        assert results.shape[1] == sum([len(state_vars) for state_vars in self.state_variable_names])
+        # get union of state variables
+        names_union = set.union(*[set(state_vars) for state_vars in self.state_variable_names])
+        num_nodes = len(self.state_variable_names)
+
+        # init empty DataArrays per state variable
+        xr_results = {
+            state_var: xr.DataArray(
+                None,
+                dims=["time", "node"],
+                coords={"time": np.around(times / 1000.0, 5), "node": np.arange(num_nodes),},
+            )
+            for state_var in names_union
+        }
+
+        # track index in results
+        var_idx = 0
+        for node_idx, node_results in enumerate(self.state_variable_names):
+            for result_idx, result in enumerate(node_results):
+                xr_results[result][:, node_idx] = results[:, var_idx + result_idx].astype(np.floating)
+            var_idx += len(node_results)
+
+        for state_var, array in xr_results.items():
+            xr_results[state_var] = array.astype(np.floating)
+
+        dataset = xr.Dataset(xr_results)
+        dataset.attrs = attributes or {}
+
+        return dataset
+
+    @staticmethod
+    def save_to_pickle(datafield, filename):
+        """
+        Save datafield to pickle file. Keep in mind that restoring a pickle
+        requires that the internal structure of the types for the pickled data
+        remain unchanged, o.e. not recommended for long-term storage.
+
+        :param datafield: datafield to save
+        :type datafield: xr.Dataset
+        :param filename: filename
+        :type filename: str
+        """
+        if not filename.endswith(".pkl"):
+            filename += ".pkl"
+        with open(filename, "wb") as handle:
+            pickle.dump(datafield, handle, protocol=pickle.HIGHEST_PROTOCOL)
+
+    @staticmethod
+    def _save_attrs_json(attrs, filename):
+        """
+        Save attributes to json.
+        """
+
+        def sanitise_attrs(attrs):
+            sanitised = {}
+            for k, v in attrs.items():
+                if isinstance(v, list):
+                    sanitised[k] = [
+                        sanitise_attrs(vv)
+                        if isinstance(vv, dict)
+                        else vv.tolist()
+                        if isinstance(vv, np.ndarray)
+                        else vv
+                        for vv in v
+                    ]
+                elif isinstance(v, dict):
+                    sanitised[k] = sanitise_attrs(v)
+                elif isinstance(v, np.ndarray):
+                    sanitised[k] = v.tolist()
+                else:
+                    sanitised[k] = v
+            return sanitised
+
+        filename = os.path.splitext(filename)[0] + ".json"
+        with open(filename, "w") as handle:
+            json.dump(sanitise_attrs(attrs), handle)
+
+    def save_to_netcdf(self, datafield, filename):
+        """
+        Save datafield to NetCDF. NetCDF cannot handle structured attributes,
+        hence they are stripped and if there are some, they are saved as json
+        with the same filename.
+
+        :param datafield: datafield to save
+        :type datafield: xr.Dataset
+        :param filename: filename
+        :type filename: str
+        """
+        datafield = deepcopy(datafield)
+        if not filename.endswith(".nc"):
+            filename += ".nc"
+        if datafield.attrs:
+            attributes_copy = deepcopy(datafield.attrs)
+            self._save_attrs_json(attributes_copy, filename)
+            datafield.attrs = {}
+        datafield.to_netcdf(filename)
+
+    def clean(self):
+        """
+        Clean after myself, if needed.
+        """
+        self.backend_instance.clean()

--- a/neurolib/models/multimodel/builder/base/backend.py
+++ b/neurolib/models/multimodel/builder/base/backend.py
@@ -10,7 +10,7 @@ backends:
     - reasonable speed
 
  - `numba`: compilation of python code through `numba.njit()` - symbolic
-    derivatives are converted to strings and prepared and compiled to 
+    derivatives are converted to strings and prepared and compiled to
     numba-compatible python code; Equations are integrated using the Euler
     integration scheme.
     - Euler scheme could be less reliable
@@ -209,7 +209,7 @@ def integrate(dt, n, max_delay, t_max, y0, input_y):
         derivatives_str = self._replace_past_ys(derivatives_str, dt=dt)
         assert isinstance(derivatives_str, str)
         logging.info("Compiling python code using numba's njit...")
-        numba_func = self.NUMBA_STRING_TEMPLATE.format(dt=dt, dy_eqs=derivatives_str)
+        numba_func = self.NUMBA_EULER_TEMPLATE.format(dy_eqs=derivatives_str)
         # compile numba function and load into namespace
         numba_code = compile(numba_func, "<string>", "exec")
         integrate = numba.njit(
@@ -494,7 +494,7 @@ class BackendIntegrator:
             state_var: xr.DataArray(
                 None,
                 dims=["time", "node"],
-                coords={"time": np.around(times / 1000.0, 5), "node": np.arange(num_nodes),},
+                coords={"time": np.around(times / 1000.0, 5), "node": np.arange(num_nodes)},
             )
             for state_var in names_union
         }

--- a/neurolib/models/multimodel/builder/base/constants.py
+++ b/neurolib/models/multimodel/builder/base/constants.py
@@ -1,0 +1,20 @@
+"""
+Set of constants for model building.
+"""
+
+### -- NAMING CONVENTIONS --
+# names for excitatory and inhibitory masses
+EXC = "EXC"
+INH = "INH"
+# names for three levels of hierarchy
+NETWORK_NAME_STR = "net"
+NODE_NAME_STR = "node"
+MASS_NAME_STR = "mass"
+# names for matrices
+NODAL_CONNECTIVITY = "local_connectivity"
+NODAL_DELAYS = "local_delays"
+NETWORK_CONNECTIVITY = "connectivity"
+NETWORK_DELAYS = "delays"
+
+# speed for dummy fixed-point-dynamical variable
+LAMBDA_SPEED = 10.0

--- a/neurolib/models/multimodel/builder/base/constants.py
+++ b/neurolib/models/multimodel/builder/base/constants.py
@@ -11,8 +11,8 @@ NETWORK_NAME_STR = "net"
 NODE_NAME_STR = "node"
 MASS_NAME_STR = "mass"
 # names for matrices
-NODAL_CONNECTIVITY = "local_connectivity"
-NODAL_DELAYS = "local_delays"
+NODE_CONNECTIVITY = "local_connectivity"
+NODE_DELAYS = "local_delays"
 NETWORK_CONNECTIVITY = "connectivity"
 NETWORK_DELAYS = "delays"
 

--- a/neurolib/models/multimodel/builder/base/network.py
+++ b/neurolib/models/multimodel/builder/base/network.py
@@ -715,12 +715,12 @@ class Network(BackendIntegrator):
         """
         network_equations = []
         var_idx = 0
-        for node_idx, node in enumerate(self.nodes):
+        for node in self.nodes:
             node.idx_state_var = var_idx
             network_coupling = {
                 self._strip_index(key): value
                 for key, value in self.sync_symbols.items()
-                if self._strip_node_idx(key) == node_idx
+                if self._strip_node_idx(key) == node.index
             }
             network_equations += node._derivatives(network_coupling)
             var_idx += node.num_state_variables

--- a/neurolib/models/multimodel/builder/base/network.py
+++ b/neurolib/models/multimodel/builder/base/network.py
@@ -58,6 +58,9 @@ class Node(BackendIntegrator):
         self.idx_state_var = None
         self.initialised = False
         assert self.default_output in self.state_variable_names[0]
+        # mass types needs to be unique for all masses!
+        mass_types = [mass.mass_type for mass in self]
+        assert len(set(mass_types)) == len(mass_types), f"Mass types needs to be different: {mass_types}"
 
     def __str__(self):
         """
@@ -96,7 +99,7 @@ class Node(BackendIntegrator):
     @property
     def state_variable_names(self):
         state_var_names = sum([mass.state_variable_names for mass in self], [])
-        # if state variables are not unique per node, append mass label to them
+        # if state variables are not unique per node, append mass type to them
         if len(state_var_names) != len(set(state_var_names)):
             state_var_names = [
                 f"{state_var}_{mass.mass_type}" for mass in self for state_var in mass.state_variable_names

--- a/neurolib/models/multimodel/builder/base/network.py
+++ b/neurolib/models/multimodel/builder/base/network.py
@@ -15,8 +15,8 @@ from .constants import (
     NETWORK_CONNECTIVITY,
     NETWORK_DELAYS,
     NETWORK_NAME_STR,
-    NODAL_CONNECTIVITY,
-    NODAL_DELAYS,
+    NODE_CONNECTIVITY,
+    NODE_DELAYS,
     NODE_NAME_STR,
 )
 from .neural_mass import NeuralMass
@@ -24,7 +24,7 @@ from .neural_mass import NeuralMass
 
 class Node(BackendIntegrator):
     """
-    Base class for all nodes within the whole-brain network.
+    Base class for all nodes within the network.
     """
 
     name = ""
@@ -306,7 +306,7 @@ class SingleCouplingExcitatoryInhibitoryNode(Node):
         """
         return {
             **super().describe(),
-            **{NODAL_CONNECTIVITY: self.connectivity, NODAL_DELAYS: self.delays},
+            **{NODE_CONNECTIVITY: self.connectivity, NODE_DELAYS: self.delays},
         }
 
     @property
@@ -322,8 +322,8 @@ class SingleCouplingExcitatoryInhibitoryNode(Node):
         """
         nested_params = super().get_nested_params()
         node_key = f"{NODE_NAME_STR}_{self.index}"
-        nested_params[node_key][NODAL_CONNECTIVITY] = self.connectivity
-        nested_params[node_key][NODAL_DELAYS] = self.delays
+        nested_params[node_key][NODE_CONNECTIVITY] = self.connectivity
+        nested_params[node_key][NODE_DELAYS] = self.delays
 
         return nested_params
 
@@ -354,8 +354,8 @@ class SingleCouplingExcitatoryInhibitoryNode(Node):
         Update params - also update local connectivity and local delays,
         then pass to base class.
         """
-        local_connectivity = params_dict.pop(NODAL_CONNECTIVITY, None)
-        local_delays = params_dict.pop(NODAL_DELAYS, None)
+        local_connectivity = params_dict.pop(NODE_CONNECTIVITY, None)
+        local_delays = params_dict.pop(NODE_DELAYS, None)
         if local_connectivity is not None and isinstance(local_connectivity, np.ndarray):
             assert local_connectivity.shape == self.connectivity.shape
             self.connectivity = local_connectivity

--- a/neurolib/models/multimodel/builder/base/network.py
+++ b/neurolib/models/multimodel/builder/base/network.py
@@ -33,7 +33,7 @@ class Node(BackendIntegrator):
     # index of this node with respect to the whole network
     index = None
 
-    # list of synchronisation variables that are used to compute input/output
+    # list of coupling variables that are used to compute input/output
     # from different masses in this node, implemented as `jitcdde` helpers
     sync_variables = []
 
@@ -41,7 +41,7 @@ class Node(BackendIntegrator):
     # usually used for isolated node
     default_network_coupling = {}
 
-    # default output of the model - all nodes need to have this variable defined
+    # default output of the node - all nodes need to have this variable defined
     default_output = None
 
     def __init__(self, neural_masses):
@@ -145,7 +145,7 @@ class Node(BackendIntegrator):
 
     def update_params(self, params_dict):
         """
-        Update parameters of the node, i.e. recursively update all the masses.
+        Update parameters of the node, i.e. recursively update all parameters of masses within this node.
 
         :param params_dict: new parameters for this node, same format as
             `get_nested_params`, i.e. nested dict
@@ -159,6 +159,13 @@ class Node(BackendIntegrator):
             else:
                 logging.warning(f"Not sure what to do with {mass_key}...")
 
+    @staticmethod
+    def _get_index(symbol_name):
+        """
+        Gets index value from the symbol name.
+        """
+        return int(symbol_name.split("_")[-1])
+        
     @staticmethod
     def _strip_index(symbol_name):
         """
@@ -191,17 +198,17 @@ class Node(BackendIntegrator):
     @property
     def initial_state(self):
         """
-        Return initial state of this node, i.e. sum of masses initial states.
+        Return initial state of this node, i.e. sum of initial states of all masses.
         """
         return np.array(sum([mass.initial_state for mass in self], [],))
 
     def all_couplings(self, mass_indices=None):
         """
-        Return all couplings from masses denoted by index.
+        Return coupling variable names of all masses within this node, denoted by each masses index.
 
-        :param mass_indices: indices as to which mass to probe
+        :param mass_indices: indices of masses
         :type mass_indices: list|None
-        :return: coupling from all masses indicated in the mass_indices
+        :return: coupling variables from all masses indexed by mass_indices
         :rtype: dict
         """
         mass_indices = mass_indices or np.arange(len(self.masses)).tolist()

--- a/neurolib/models/multimodel/builder/base/network.py
+++ b/neurolib/models/multimodel/builder/base/network.py
@@ -1,0 +1,717 @@
+"""
+Base for "network" and "node" operations on neural masses.
+"""
+import logging
+
+import numpy as np
+import symengine as se
+from jitcdde import t as time_vector
+from jitcdde import y as state_vector
+
+from .backend import BackendIntegrator
+from .constants import (
+    EXC,
+    MASS_NAME_STR,
+    NETWORK_CONNECTIVITY,
+    NETWORK_DELAYS,
+    NETWORK_NAME_STR,
+    NODAL_CONNECTIVITY,
+    NODAL_DELAYS,
+    NODE_NAME_STR,
+)
+from .neural_mass import NeuralMass
+
+
+class Node(BackendIntegrator):
+    """
+    Base class for all nodes within the whole-brain network.
+    """
+
+    name = ""
+    label = ""
+
+    # index of this node with respect to the whole network
+    index = None
+
+    # list of synchronisation variables that are used to compute input/output
+    # from different masses in this node, implemented as `jitcdde` helpers
+    sync_variables = []
+
+    # default network coupling - will be used if network coupling is None,
+    # usually used for isolated node
+    default_network_coupling = {}
+
+    # default output of the model - all nodes need to have this variable defined
+    default_output = None
+
+    def __init__(self, neural_masses):
+        """
+        :param neural_masses: list of neural masses in this node
+        :type neural_masses: list[NeuralMass]
+        """
+        assert all(isinstance(mass, NeuralMass) for mass in neural_masses)
+        self.masses = neural_masses
+        # number of state variables for whole node, i.e. sum of state variables
+        # for all masses
+        self.num_state_variables = sum([mass.num_state_variables for mass in self])
+        self.num_noise_variables = sum([mass.num_noise_variables for mass in self])
+        self.idx_state_var = None
+        self.initialised = False
+        assert self.default_output in self.state_variable_names[0]
+
+    def __str__(self):
+        """
+        String representation.
+        """
+        return (
+            f"Network node: {self.name} with {len(self.masses)} neural mass(es)"
+            f": {', '.join([mass.name for mass in self])}"
+        )
+
+    def describe(self):
+        """
+        Return description dict.
+        """
+        return {
+            "index": self.index,
+            "name": self.name,
+            "num_masses": len(self),
+            "num_num_state_variables": self.num_state_variables,
+            "num_noise_variables": self.num_noise_variables,
+            "masses": [mass.describe() for mass in self],
+        }
+
+    def __len__(self):
+        """
+        Get length.
+        """
+        return len(self.masses)
+
+    def __getitem__(self, index):
+        """
+        Get item.
+        """
+        return self.masses[index]
+
+    @property
+    def state_variable_names(self):
+        state_var_names = sum([mass.state_variable_names for mass in self], [])
+        # if state variables are not unique per node, append mass label to them
+        if len(state_var_names) != len(set(state_var_names)):
+            state_var_names = [
+                f"{state_var}_{mass.mass_type}" for mass in self for state_var in mass.state_variable_names
+            ]
+        return [state_var_names]
+
+    @property
+    def max_delay(self):
+        return 0.0
+
+    def get_nested_parameters(self):
+        """
+        Return nested dictionary with parameters from all masses within this
+        node.
+
+        :return: nested dictionary with all parameters
+        :rtype: dict
+        """
+        assert self.initialised
+        node_key = f"{NODE_NAME_STR}_{self.index}"
+        nested_dict = {node_key: {}}
+        for mass in self:
+            mass_key = f"{MASS_NAME_STR}_{mass.index}"
+            nested_dict[node_key][mass_key] = mass.parameters
+        return nested_dict
+
+    def init_node(self, **kwargs):
+        """
+        Initialise node and all the masses within.
+
+        :kwargs: optional keyword arguments to init_mass
+        """
+        # we need to have the index already assigned
+        assert self.index is not None
+        # initialise possible sync variables
+        self.sync_symbols = {
+            f"{symbol}_{self.index}": se.Symbol(f"{symbol}_{self.index}") for symbol in self.sync_variables
+        }
+        for mass in self:
+            mass.init_mass(**kwargs)
+        assert all(mass.initialised for mass in self)
+        self.initialised = True
+
+    def update_parameters(self, parameters_dict):
+        """
+        Update parameters of the node, i.e. recursively update all the masses.
+
+        :param parameters_dict: new parameters for this node, same format as
+            `get_nested_parameters`, i.e. nested dict
+        :type parameters_dict: dict
+        """
+        for mass_key, mass_params in parameters_dict.items():
+            if MASS_NAME_STR in mass_key:
+                mass_index = int(mass_key.split("_")[-1])
+                assert mass_index == self.masses[mass_index].index
+                self.masses[mass_index].update_parameters(mass_params)
+            else:
+                logging.warning(f"Not sure what to do with {mass_key}...")
+
+    @staticmethod
+    def _strip_index(symbol_name):
+        """
+        Strip index value from the symbol name.
+        """
+        return "_".join(symbol_name.split("_")[:-1])
+
+    def _callbacks(self):
+        """
+        Gather callbacks from all masses.
+        """
+        return sum([mass._callbacks() for mass in self.masses], [])
+
+    def _numba_callbacks(self):
+        """
+        Gather callbacks from all masses.
+        """
+        return sum([mass._numba_callbacks() for mass in self.masses], [])
+
+    def _sync(self):
+        """
+        Define synchronisation step for the node. This should define the helper
+        and its equations. Must be symbolic, i.e. defined with basic math
+        operators and symengine operations on state vector. Should return list
+        as
+        [(se.Symbol, <symbolic definition>)]
+        """
+        raise NotImplementedError
+
+    @property
+    def initial_state(self):
+        """
+        Return initial state of this node, i.e. sum of masses initial states.
+        """
+        return np.array(sum([mass.initial_state for mass in self], [],))
+
+    def all_couplings(self, mass_indices=None):
+        """
+        Return all couplings from masses denoted by index.
+
+        :param mass_indices: indices as to which mass to probe
+        :type mass_indices: list|None
+        :return: coupling from all masses indicated in the mass_indices
+        :rtype: dict
+        """
+        mass_indices = mass_indices or np.arange(len(self.masses)).tolist()
+        all_couplings = {}
+        var_idx = 0
+        for mass_idx, mass in enumerate(self.masses):
+            if mass_idx in mass_indices:
+                all_couplings.update({var_idx + k: v for k, v in mass.coupling_variables.items()})
+            var_idx += mass.num_state_variables
+        return all_couplings
+
+    def _derivatives(self, network_coupling=None):
+        """
+        Gather all derivatives from all masses.
+
+        :param network_coupling: dict of network coupling for this node, if
+            None, default network coupling will be used
+        :type network_coupling: dict|None
+        :return: derivatives of the state vector for this node
+        :rtype: list
+        """
+        if network_coupling is None:
+            network_coupling = self.default_network_coupling
+        node_system_equations = []
+        var_idx = 0
+        for mass in self:
+            # get coupling variables
+            coupling_vars = {
+                self._strip_index(key): value
+                for key, value in self.sync_symbols.items()
+                if self._strip_index(key) in mass.required_couplings
+            }
+            coupling_vars.update(
+                {key: value for key, value in network_coupling.items() if key in mass.required_couplings}
+            )
+            mass.idx_state_var = self.idx_state_var + var_idx
+            node_system_equations += mass._derivatives(coupling_vars)
+            var_idx += mass.num_state_variables
+        assert len(node_system_equations) == self.num_state_variables
+        return node_system_equations
+
+
+class SingleCouplingExcitatoryInhibitoryNode(Node):
+    """
+    Basic node with arbitrary number of excitatory and inhibitory populations,
+    but the coupling is through one variable - usually firing rate of the
+    population. Will compute connectivity within node as per population types.
+    This node definition assumes constant delays, i.e. not dependent on time
+    nor dynamics (state variables).
+    """
+
+    name = "Single coupling excitatory vs inhibitory node"
+    label = "1ExcInhNode"
+
+    sync_variables = [
+        "node_exc_exc",
+        "node_inh_exc",
+        "node_exc_inh",
+        "node_inh_inh",
+    ]
+
+    # default network coupling - only EXC to EXC and defaults to 0.0 - no
+    # network
+    default_network_coupling = {"network_exc_exc": 0.0}
+
+    def __init__(
+        self, neural_masses, local_connectivity, local_delays=None,
+    ):
+        """
+        :param neural_masses: list of neural masses in this node
+        :type neural_masses: list[NeuralMass]
+        :param local_connectivity: connectivity matrix for within node
+            connections - same order as neural masses, matrix as [from, to]
+        :type local_connectivity: np.ndarray
+        :param local_delays: delay matrix for within node connections - same
+            order as neural masses, if None, delays are all zeros, in ms,
+            matrix as [from, to]
+        :type local_delays: np.ndarray|None
+        """
+        super().__init__(neural_masses=neural_masses)
+        # assert all masses have one coupling variable
+        assert all(len(mass.coupling_variables) == 1 for mass in self.masses)
+        # check length - should be the len of masses
+        assert local_connectivity.shape[0] == len(self.masses)
+        if local_delays is None:
+            local_delays = np.zeros_like(local_connectivity)
+        assert local_connectivity.shape == local_delays.shape
+        self.connectivity = local_connectivity
+        self.delays = local_delays
+        self.excitatory_masses = np.array([mass.mass_type == EXC for mass in self.masses])
+        self.inhibitory_masses = ~self.excitatory_masses
+        self.excitatory_masses = np.where(self.excitatory_masses)[0]
+        self.inhibitory_masses = np.where(self.inhibitory_masses)[0]
+
+    def __str__(self):
+        """
+        String representation.
+        """
+        mass_names = ", ".join([f"{mass.name} {mass.mass_type}" for mass in self.masses])
+        return f"Network node: {self.name} with {len(self.masses)} neural masses:" f" {mass_names}"
+
+    def describe(self):
+        """
+        Return description dict.
+        """
+        return {
+            **super().describe(),
+            **{NODAL_CONNECTIVITY: self.connectivity, NODAL_DELAYS: self.delays},
+        }
+
+    @property
+    def max_delay(self):
+        return np.max(self.delays)
+
+    def get_nested_parameters(self):
+        """
+        Add local connectivity and local delays matrices to mass parameters.
+
+        :return: nested parameters containing also connectivity
+        :rtype: dict
+        """
+        nested_params = super().get_nested_parameters()
+        node_key = f"{NODE_NAME_STR}_{self.index}"
+        nested_params[node_key][NODAL_CONNECTIVITY] = self.connectivity
+        nested_params[node_key][NODAL_DELAYS] = self.delays
+
+        return nested_params
+
+    def init_node(self):
+        super().init_node()
+        assert self.idx_state_var is not None
+        # gather inputs form this node - assumes constant delays
+        var_idx = 0
+        self.inputs = []
+        for row, mass in enumerate(self.masses):
+            self.inputs.append(
+                [
+                    state_vector(
+                        self.idx_state_var  # starting index of this node
+                        + var_idx  # starting index of particular mass
+                        + next(iter(mass.coupling_variables)),  # index of coupling variable
+                        time=time_vector - self.delays[row, col],
+                    )
+                    for col in range(len(self.masses))
+                ]
+            )
+            var_idx += mass.num_state_variables
+        # inputs as matrix [from, to]
+        self.inputs = np.array(self.inputs)
+
+    def update_parameters(self, parameters_dict):
+        """
+        Update parameters - also update local connectivity and local delays,
+        then pass to base class.
+        """
+        local_connectivity = parameters_dict.pop(NODAL_CONNECTIVITY, None)
+        local_delays = parameters_dict.pop(NODAL_DELAYS, None)
+        if local_connectivity is not None and isinstance(local_connectivity, np.ndarray):
+            assert local_connectivity.shape == self.connectivity.shape
+            self.connectivity = local_connectivity
+        if local_delays is not None and isinstance(local_delays, np.ndarray):
+            assert local_delays.shape == self.delays.shape
+            self.delays = local_delays
+        super().update_parameters(parameters_dict)
+
+    def _sync(self):
+        connectivity = self.connectivity * self.inputs
+        return [
+            (
+                self.sync_symbols[f"node_exc_exc_{self.index}"],
+                sum([connectivity[row, col] for row in self.excitatory_masses for col in self.excitatory_masses]),
+            ),
+            (
+                self.sync_symbols[f"node_inh_exc_{self.index}"],
+                sum([connectivity[row, col] for row in self.inhibitory_masses for col in self.excitatory_masses]),
+            ),
+            (
+                self.sync_symbols[f"node_exc_inh_{self.index}"],
+                sum([connectivity[row, col] for row in self.excitatory_masses for col in self.inhibitory_masses]),
+            ),
+            (
+                self.sync_symbols[f"node_inh_inh_{self.index}"],
+                sum([connectivity[row, col] for row in self.inhibitory_masses for col in self.inhibitory_masses]),
+            ),
+        ]
+
+
+class Network(BackendIntegrator):
+    """
+    Base class for brain network.
+    """
+
+    name = ""
+    label = ""
+
+    # list of synchronisation variables that are used to compute input/output
+    # from different nodes in this network, implemented as `jitcdde` helpers
+    sync_variables = []
+
+    # default output of the network - e.g. BOLD is computed from this
+    default_output = None
+
+    def __init__(self, nodes, connectivity_matrix, delay_matrix=None):
+        """
+        :param nodes: list of nodes in this network
+        :type nodes: list[Node]
+        :param connectivity_matrix: connectivity matrix for between nodes
+            coupling, typically DTI structural connectivity, matrix as [from,
+            to]
+        :type connectivity_matrix: np.ndarray
+        :param delay_matrix: delay matrix between nodes, typically derived from
+            length matrix, if None, delays are all zeros, in ms, matrix as
+            [from, to]
+        :type delay_matrix: np.ndarray|None
+        """
+        # assert all(isinstance(node, Node) for node in nodes)
+        self.nodes = nodes
+        self.num_state_variables = sum([node.num_state_variables for node in self])
+        self.num_noise_variables = sum([node.num_noise_variables for node in self])
+        assert connectivity_matrix.shape[0] == self.num_nodes
+        if delay_matrix is None:
+            delay_matrix = np.zeros_like(connectivity_matrix)
+        assert connectivity_matrix.shape == delay_matrix.shape
+        self.connectivity = connectivity_matrix
+        self.delays = delay_matrix
+        self.initialised = False
+
+        if self.default_output is None:
+            default_output = set([node.default_output for node in self])
+            assert len(default_output) == 1
+            self.default_output = next(iter(default_output))
+
+        assert all(self.default_output in node_state_vars for node_state_vars in self.state_variable_names)
+
+        self.init_network()
+
+    def __str__(self):
+        """
+        String representation.
+        """
+        return f"Brain network {self.name} with {self.num_nodes} nodes"
+
+    def describe(self):
+        """
+        Return description dict.
+        """
+        return {
+            "name": self.name,
+            "num_nodes": self.num_nodes,
+            "num_state_variables": self.num_state_variables,
+            "num_noise_variables": self.num_noise_variables,
+            "nodes": [node.describe() for node in self],
+            NETWORK_CONNECTIVITY: self.connectivity,
+            NETWORK_DELAYS: self.delays,
+        }
+
+    def __len__(self):
+        """
+        Get length.
+        """
+        return len(self.nodes)
+
+    def __getitem__(self, index):
+        """
+        Get item.
+        """
+        return self.nodes[index]
+
+    @property
+    def max_delay(self):
+        return np.max(self.delays.flatten().tolist() + [node.max_delay for node in self])
+
+    @property
+    def num_nodes(self):
+        return len(self.nodes)
+
+    @property
+    def state_variable_names(self):
+        state_var_names = sum([node.state_variable_names for node in self], [])
+        assert len(state_var_names) == self.num_nodes
+        return state_var_names
+
+    @property
+    def initial_state(self):
+        """
+        Return initial state for whole network.
+        """
+        return np.concatenate([node.initial_state for node in self], axis=0)
+
+    @staticmethod
+    def _strip_index(symbol_name):
+        """
+        Strip index value from the symbol name.
+        """
+        return "_".join(symbol_name.split("_")[:-1])
+
+    @staticmethod
+    def _strip_node_idx(symbol_name):
+        """
+        Keep index value from the symbol name.
+        """
+        return int(symbol_name.split("_")[-1])
+
+    @staticmethod
+    def _prepare_mass_parameters(param, num_nodes, native_type=dict):
+        """
+        Prepare mass parameters for the network. I.e. extend to list of the
+        same length as number of nodes.
+
+        :param param: parameters to check / prepare
+        :type param: list[native_type]|native_type|None
+        :param num_nodes: number of nodes in the network
+        :type num_nodes: int
+        """
+        if param is None:
+            param = [None] * num_nodes
+        if isinstance(param, native_type):
+            param = [param] * num_nodes
+        assert isinstance(param, list)
+        assert all(p is None or isinstance(p, native_type) for p in param)
+        assert len(param) == num_nodes
+        return param
+
+    def get_nested_parameters(self):
+        """
+        Return nested dictionary with parameters from all nodes and all masses
+        within this network.
+
+        :return: nested dictionary with all parameters
+        :rtype: dict
+        """
+        assert self.initialised
+        nested_dict = {NETWORK_NAME_STR: {}}
+        for node in self:
+            nested_dict[NETWORK_NAME_STR].update(node.get_nested_parameters())
+        nested_dict[NETWORK_CONNECTIVITY] = self.connectivity
+        nested_dict[NETWORK_DELAYS] = self.delays
+        return nested_dict
+
+    def init_network(self, **kwargs):
+        """
+        Initialise network and the nodes within.
+
+        :kwargs: optional keyword arguments to init_node
+        """
+        # create symbol for each node for input
+        self.sync_symbols = {
+            f"{symbol}_{node_idx}": se.Symbol(f"{symbol}_{node_idx}")
+            for symbol in self.sync_variables
+            for node_idx in range(self.num_nodes)
+        }
+        for node in self:
+            node.init_node(**kwargs)
+        assert all(node.initialised for node in self)
+        self.initialised = True
+
+    def update_parameters(self, parameters_dict):
+        """
+        Update parameters of this network, i.e. recursively for all nodes and
+        all masses.
+
+        :param parameters_dict: new parameters for the network
+        :type parameters_dict: dict
+        """
+        for node_key, node_params in parameters_dict.items():
+            if NODE_NAME_STR in node_key:
+                node_index = int(node_key.split("_")[-1])
+                assert node_index == self.nodes[node_index].index
+                self.nodes[node_index].update_parameters(node_params)
+            elif NETWORK_CONNECTIVITY == node_key:
+                assert node_params.shape == self.connectivity.shape
+                self.connectivity = node_params
+            elif NETWORK_DELAYS == node_key:
+                assert node_params.shape == self.delays.shape
+                self.delays = node_params
+            else:
+                logging.warning(f"Not sure what to do with {node_key}...")
+
+    def _callbacks(self):
+        """
+        Gather callbacks from all nodes.
+        """
+        return sum([node._callbacks() for node in self.nodes], [])
+
+    def _numba_callbacks(self):
+        """
+        Gather callbacks from all nodes.
+        """
+        return sum([node._numba_callbacks() for node in self.nodes], [])
+
+    def _sync(self):
+        """
+        Define synchronisation step for whole network. This should define helper
+        and its equations. Must be symbolic, i.e. defined with basic math
+        operators and symengine operations on state vector. Should return list
+        as
+        [(se.Symbol, <symbolic definition>)]
+        """
+        return sum([node._sync() for node in self], [])
+
+    def _construct_input_matrix(self, within_node_idx):
+        """
+        Construct input matrix as [from, to] with correct state variables and
+        delays.
+
+        :param within_node_idx: index of coupling variable within node (! not
+            mass), either single index or list of indices
+        :type within_node_idx: list[int]|int
+        :return: matrix of delayed inputs as [from, to]
+        :rtype: np.ndarray
+        """
+        var_idx = 0
+        inputs = []
+        if isinstance(within_node_idx, int):
+            within_node_idx = [within_node_idx] * self.num_nodes
+        assert self.num_nodes == len(within_node_idx)
+
+        for row, (node, node_var_idx) in enumerate(zip(self.nodes, within_node_idx)):
+            inputs.append(
+                [
+                    state_vector(var_idx + node_var_idx, time=time_vector - self.delays[row, col],)
+                    for col in range(self.num_nodes)
+                ]
+            )
+            var_idx += node.num_state_variables
+        # node inputs as matrix [from, to]
+        return np.array(inputs)
+
+    def _no_coupling(self, symbol):
+        """
+        Turn off coupling for given symbol.
+
+        :param symbol: which symbol to fill with the data
+        :type symbol: str
+        """
+        return [(self.sync_symbols[f"{symbol}_{node_idx}"], 0.0) for node_idx in range(self.num_nodes)]
+
+    def _diffusive_coupling(self, within_node_idx, symbol, connectivity_multiplier=1.0):
+        """
+        Perform diffusive coupling on the network with given symbol, i.e.
+            network_inp = SUM_idx(Cmat[idx, to] * (X[idx](t - Dmat) - X[to](t)))
+
+        :param within_node_idx: index of coupling variable within node (! not
+            mass), either single index or list of indices
+        :type within_node_idx: list[int]|int
+        :param symbol: which symbol to fill with the data
+        :type symbol: str
+        :param connectivity_multiplier: multiplier for connectivity, either
+            scalar, or array broadcastable to connectivity
+        :type connectivity_multiplier: float|np.ndarray
+        """
+        assert symbol in self.sync_variables
+        if isinstance(within_node_idx, int):
+            within_node_idx = [within_node_idx] * self.num_nodes
+        assert self.num_nodes == len(within_node_idx)
+        inputs = self._construct_input_matrix(within_node_idx)
+        connectivity = self.connectivity * connectivity_multiplier
+        var_idx = 0
+        helpers = []
+        for node_idx, node_var_idx in zip(range(self.num_nodes), within_node_idx):
+            helpers.append(
+                (
+                    self.sync_symbols[f"{symbol}_{node_idx}"],
+                    sum(
+                        [
+                            connectivity[row, node_idx]
+                            * (inputs[row, node_idx] - state_vector(var_idx + node_var_idx, time=time_vector))
+                            for row in range(self.num_nodes)
+                        ]
+                    ),
+                )
+            )
+            var_idx += self.nodes[node_idx].num_state_variables
+        return helpers
+
+    def _additive_coupling(self, within_node_idx, symbol, connectivity_multiplier=1.0):
+        """
+        Perform additive coupling on the network within given symbol, i.e.
+            network_inp = SUM_idx(Cmat[idx, to] * X[idx](t - Dmat))
+
+        :param within_node_idx: index of coupling variable within node (! not
+            mass), either single index or list of indices
+        :type within_node_idx: list[int]|int
+        :param symbol: which symbol to fill with the data
+        :type symbol: str
+        :param connectivity_multiplier: multiplier for connectivity, either
+            scalar, or array broadcastable to connectivity
+        :type connectivity_multiplier: float|np.ndarray
+        """
+        assert symbol in self.sync_variables
+        connectivity = self.connectivity * connectivity_multiplier * self._construct_input_matrix(within_node_idx)
+        return [
+            (
+                self.sync_symbols[f"{symbol}_{node_idx}"],
+                sum([connectivity[row, node_idx] for row in range(self.num_nodes)]),
+            )
+            for node_idx in range(self.num_nodes)
+        ]
+
+    def _derivatives(self):
+        """
+        Gather all derivatives from all nodes.
+        """
+        network_equations = []
+        var_idx = 0
+        for node_idx, node in enumerate(self.nodes):
+            node.idx_state_var = var_idx
+            network_coupling = {
+                self._strip_index(key): value
+                for key, value in self.sync_symbols.items()
+                if self._strip_node_idx(key) == node_idx
+            }
+            network_equations += node._derivatives(network_coupling)
+            var_idx += node.num_state_variables
+        assert len(network_equations) == self.num_state_variables
+        return network_equations

--- a/neurolib/models/multimodel/builder/base/network.py
+++ b/neurolib/models/multimodel/builder/base/network.py
@@ -232,7 +232,7 @@ class Node(BackendIntegrator):
         """
         if network_coupling is None:
             network_coupling = self.default_network_coupling
-        node_system_equations = []
+        node_equation_system = []
         var_idx = 0
         for mass in self:
             # get coupling variables
@@ -245,19 +245,17 @@ class Node(BackendIntegrator):
                 {key: value for key, value in network_coupling.items() if key in mass.required_couplings}
             )
             mass.idx_state_var = self.idx_state_var + var_idx
-            node_system_equations += mass._derivatives(coupling_vars)
+            node_equation_system += mass._derivatives(coupling_vars)
             var_idx += mass.num_state_variables
-        assert len(node_system_equations) == self.num_state_variables
-        return node_system_equations
+        assert len(node_equation_system) == self.num_state_variables
+        return node_equation_system
 
 
 class SingleCouplingExcitatoryInhibitoryNode(Node):
     """
     Basic node with arbitrary number of excitatory and inhibitory populations,
     but the coupling is through one variable - usually firing rate of the
-    population. Will compute connectivity within node as per population types.
-    This node definition assumes constant delays, i.e. not dependent on time
-    nor dynamics (state variables).
+    population. Will compute connectivity within node as per mass types.
     """
 
     name = "Single coupling excitatory vs inhibitory node"

--- a/neurolib/models/multimodel/builder/base/neural_mass.py
+++ b/neurolib/models/multimodel/builder/base/neural_mass.py
@@ -40,7 +40,7 @@ class NeuralMass:
     state_variable_names = []
 
     # list of required parameters for this mass
-    required_parameters = []
+    required_params = []
 
     # list of helper variables that are defined as symengine Symbols - these
     # are passed to the jitc*de integrators as helpers
@@ -65,16 +65,16 @@ class NeuralMass:
         "num_state_variables",
         "num_noise_variables",
         "state_variable_names",
-        "parameters",
+        "params",
     ]
 
-    def __init__(self, parameters):
+    def __init__(self, params):
         """
-        :param parameters: parameters of the neural mass
-        :type parameters: dict
+        :param params: parameters of the neural mass
+        :type params: dict
         """
-        assert isinstance(parameters, dict)
-        self.parameters = parameters
+        assert isinstance(params, dict)
+        self.params = params
         # used in determining portion of the full system's state vector
         self.idx_state_var = None
         self.initialised = False
@@ -85,7 +85,7 @@ class NeuralMass:
         # initialise possible callback functions
         self.callback_functions = {function: se.Function(function) for function in self.python_callbacks}
 
-        self._validate_parameters()
+        self._validate_params()
 
     def __str__(self):
         """
@@ -108,13 +108,13 @@ class NeuralMass:
         """
         self.initial_state = [0.0] * self.num_state_variables
 
-    def _validate_parameters(self):
+    def _validate_params(self):
         """
-        Validate parameters - check if self.parameters contains all required
+        Validate parameters - check if self.params contains all required
         parameters.
         """
-        assert all(key in self.parameters for key in self.required_parameters), set(self.required_parameters) - set(
-            self.parameters.keys()
+        assert all(key in self.params for key in self.required_params), set(self.required_params) - set(
+            self.params.keys()
         )
 
     def _validate_callbacks(self, callback_list):
@@ -144,17 +144,17 @@ class NeuralMass:
             self.noise_input_idx = [start_idx_for_noise + i for i in range(self.num_noise_variables)]
         self.initialised = True
 
-    def update_parameters(self, parameters_dict):
+    def update_params(self, params_dict):
         """
         Update parameters of the mass.
 
-        :param parameters_dict: new parameters for this mass
-        :type parameters_dict: dict
+        :param params_dict: new parameters for this mass
+        :type params_dict: dict
         """
-        assert isinstance(parameters_dict, dict)
-        self.parameters.update(parameters_dict)
+        assert isinstance(params_dict, dict)
+        self.params.update(params_dict)
         # validate again
-        self._validate_parameters()
+        self._validate_params()
 
     def _callbacks(self):
         """

--- a/neurolib/models/multimodel/builder/base/neural_mass.py
+++ b/neurolib/models/multimodel/builder/base/neural_mass.py
@@ -14,7 +14,11 @@ class NeuralMass:
     name = ""
     label = ""
 
-    # type of the mass - for now excitatory or inhibitory
+    # type of the mass - usually excitatory or inhibitory,
+    # when constructing a node out of neural masses, all masses need to have
+    # unique `mass_type` assigned, so e.g. for layer-resolving nodes one can use
+    # something like "layer-1-EXC", "layer-1-INH" etc; for more types of e.g.
+    # inhibitory masses one can use "INH-type-1", "INH-type-2" etc
     mass_type = None
 
     # number of state variables that are wrapped in the `y` vector for

--- a/neurolib/models/multimodel/builder/base/neural_mass.py
+++ b/neurolib/models/multimodel/builder/base/neural_mass.py
@@ -1,6 +1,7 @@
 """
 Base for all mass models.
 """
+import numpy as np
 import symengine as se
 from jitcdde import y as state_vector
 
@@ -72,13 +73,16 @@ class NeuralMass:
         "params",
     ]
 
-    def __init__(self, params):
+    def __init__(self, params, seed=None):
         """
         :param params: parameters of the neural mass
         :type params: dict
+        :param seed: seed for random number generator
+        :type seed: int|None
         """
         assert isinstance(params, dict)
         self.params = params
+        self.seed = seed
         # used in determining portion of the full system's state vector
         self.idx_state_var = None
         self.initialised = False
@@ -110,6 +114,7 @@ class NeuralMass:
         """
         Initialize state vector. By default it is all zeroes.
         """
+        np.random.seed(self.seed)
         self.initial_state = [0.0] * self.num_state_variables
 
     def _validate_params(self):

--- a/neurolib/models/multimodel/builder/base/neural_mass.py
+++ b/neurolib/models/multimodel/builder/base/neural_mass.py
@@ -1,0 +1,200 @@
+"""
+Base for all mass models.
+"""
+import symengine as se
+from jitcdde import y as state_vector
+
+
+class NeuralMass:
+    """
+    Represent a neural population with given parameters and equations, in
+    particular, the derivatives of the state vector.
+    """
+
+    name = ""
+    label = ""
+
+    # type of the mass - for now excitatory or inhibitory
+    mass_type = None
+
+    # number of state variables that are wrapped in the `y` vector for
+    # derivatives
+    num_state_variables = 0
+
+    # indexing number of the mass - when coupling with other, one can sort
+    # based on this and then use connection matrix and/or delay matrix
+    index = None
+
+    # dict as "index: name" in the state variables vector for coupling
+    # variables, i.e. variables that are present in other populations; the name
+    # represents how are they called in other populations
+    coupling_variables = {}
+
+    # list of required couplings to this mass
+    required_couplings = []
+
+    # number of noise variables / inputs
+    num_noise_variables = 0
+
+    # names for the state variables to link them with results
+    state_variable_names = []
+
+    # list of required parameters for this mass
+    required_parameters = []
+
+    # list of helper variables that are defined as symengine Symbols - these
+    # are passed to the jitc*de integrators as helpers
+    helper_variables = []
+
+    # list of callbacks functions in pure python, that are called from the
+    # symbolic derivative, useful when part of neural dynamics cannot be
+    # expressed as symbolic expression (e.g. table lookups in AdEx models)
+    # provide names of the functions here - this name shall be used in
+    # definition of the derivative;
+    # NOTE callbacks should be defined as jitted function (i.e. decorated with
+    # `numba.njit()`, because 1. speed and 2. compatibility with numba backend)
+    python_callbacks = []
+
+    # index of noise variable within the full system's input handled by jitcdde
+    noise_input_idx = None
+
+    DESCRIPTION_FIELD = [
+        "index",
+        "name",
+        "mass_type",
+        "num_state_variables",
+        "num_noise_variables",
+        "state_variable_names",
+        "parameters",
+    ]
+
+    def __init__(self, parameters):
+        """
+        :param parameters: parameters of the neural mass
+        :type parameters: dict
+        """
+        assert isinstance(parameters, dict)
+        self.parameters = parameters
+        # used in determining portion of the full system's state vector
+        self.idx_state_var = None
+        self.initialised = False
+
+        # initialise possible helpers
+        self.helper_symbols = {symbol: se.Symbol(symbol) for symbol in self.helper_variables}
+
+        # initialise possible callback functions
+        self.callback_functions = {function: se.Function(function) for function in self.python_callbacks}
+
+        self._validate_parameters()
+
+    def __str__(self):
+        """
+        String representation.
+        """
+        return (
+            f"Neural mass: {self.name} with {self.num_state_variables} "
+            f"state variables: {', '.join(self.state_variable_names)}"
+        )
+
+    def describe(self):
+        """
+        Return description dict.
+        """
+        return {field: getattr(self, field) for field in self.DESCRIPTION_FIELD}
+
+    def _initialize_state_vector(self):
+        """
+        Initialize state vector. By default it is all zeroes.
+        """
+        self.initial_state = [0.0] * self.num_state_variables
+
+    def _validate_parameters(self):
+        """
+        Validate parameters - check if self.parameters contains all required
+        parameters.
+        """
+        assert all(key in self.parameters for key in self.required_parameters), set(self.required_parameters) - set(
+            self.parameters.keys()
+        )
+
+    def _validate_callbacks(self, callback_list):
+        """
+        Validate callbacks - mainly the length and symbolic function names.
+
+        :param callback_list: list of callbacks
+        :type callback_list: list[tuple|list]
+        """
+        assert len(callback_list) == len(self.callback_functions)
+        assert all(
+            callback_from_list[0] == callback_from_init
+            for callback_from_list, callback_from_init in zip(callback_list, self.callback_functions.values())
+        )
+        assert all(callable(callback[1]) for callback in callback_list)
+
+    def init_mass(self, start_idx_for_noise=None):
+        """
+        Initialise neural mass. Usually just initialise the state vector,
+        possibly can be subclassed and do other initialisation.
+        """
+        self._initialize_state_vector()
+        assert self.index is not None
+        if start_idx_for_noise is None:
+            start_idx_for_noise = self.index
+        if self.noise_input_idx is None:
+            self.noise_input_idx = [start_idx_for_noise + i for i in range(self.num_noise_variables)]
+        self.initialised = True
+
+    def update_parameters(self, parameters_dict):
+        """
+        Update parameters of the mass.
+
+        :param parameters_dict: new parameters for this mass
+        :type parameters_dict: dict
+        """
+        assert isinstance(parameters_dict, dict)
+        self.parameters.update(parameters_dict)
+        # validate again
+        self._validate_parameters()
+
+    def _callbacks(self):
+        """
+        List of python callbacks within the symbolic derivatives definition. By
+        default, return empty list. If needed, redefine in subclass.
+
+        NOTE: if you would like to use `numba` backend, the callbacks need to be
+        defined as so-called jitted functions, i.e. they cannot be class methods
+        but rather basic functions that are wrapped with `@numba.njit()`
+        """
+        callbacks_list = []
+        self._validate_callbacks(callbacks_list)
+        return callbacks_list
+
+    def _numba_callbacks(self):
+        """
+        List of python callbacks (see above) for numba integrator. By default,
+        returns the same callbacks as for symbolic, redefine if this need to be
+        different.
+        """
+        return self._callbacks()
+
+    def _unwrap_state_vector(self):
+        """
+        Unwrap state vector into individual variables. Uses global
+        `state_vector` from `jitc*de`.
+        """
+        return [state_vector(i) for i in range(self.idx_state_var, self.idx_state_var + self.num_state_variables,)]
+
+    def _derivatives(self, coupling_variables=None):
+        """
+        Define derivates, i.e. right-hand side of the dynamical equation
+        describing dynamics of this neural mass. Optional input is
+        `coupling variables`, should return a list of derivatives of the state
+        vector (of the same length obviously).
+
+        :param coupling_variables: optional coupling variables for the mass, as
+            a dictionary {"coupling variable name": symengine.Function}
+        :type coupling_variables: dict|None
+        :return: derivatives of the state vector
+        :rtype: list
+        """
+        raise NotImplementedError

--- a/neurolib/models/multimodel/builder/hopf.py
+++ b/neurolib/models/multimodel/builder/hopf.py
@@ -1,0 +1,178 @@
+"""
+Hopf normal form model.
+
+References:
+    Kuznetsov, Y. A. (2013). Elements of applied bifurcation theory (Vol. 112).
+    Springer Science & Business Media.
+
+    Deco, G., Cabral, J., Woolrich, M. W., Stevner, A. B., Van Hartevelt, T. J.,
+    & Kringelbach, M. L. (2017). Single or multiple frequency generators in
+    on-going brain activity: A mechanistic whole-brain model of empirical MEG
+    data. Neuroimage, 152, 538-550.
+"""
+
+import numpy as np
+import symengine as se
+from jitcdde import input as system_input
+
+from ..builder.base.network import Network, Node
+from ..builder.base.neural_mass import NeuralMass
+
+DEFAULT_PARAMS = {
+    "a": 0.25,
+    "omega": 0.2,
+    "ext_input_x": 0.0,
+    "ext_input_y": 0.0,
+}
+
+
+class HopfMass(NeuralMass):
+    """
+    Hopf normal form (Landau-Stuart oscillator).
+    """
+
+    name = "Hopf normal form mass"
+    label = "HopfMass"
+
+    num_state_variables = 2
+    num_noise_variables = 2
+    coupling_variables = {0: "x", 1: "y"}
+    state_variable_names = ["x", "y"]
+    required_parameters = ["a", "omega", "ext_input_x", "ext_input_y"]
+    required_couplings = ["network_x", "network_y"]
+
+    def __init__(self, parameters=None):
+        super().__init__(parameters=parameters or DEFAULT_PARAMS)
+
+    def _initialize_state_vector(self):
+        """
+        Initialize state vector.
+        """
+        self.initial_state = [0.5 * np.random.uniform(-1, 1)] * self.num_state_variables
+
+    def _derivatives(self, coupling_variables):
+        [x, y] = self._unwrap_state_vector()
+
+        d_x = (
+            (self.parameters["a"] - x ** 2 - y ** 2) * x
+            - self.parameters["omega"] * y
+            + coupling_variables["network_x"]
+            + system_input(self.noise_input_idx[0])
+            + self.parameters["ext_input_x"]
+        )
+
+        d_y = (
+            (self.parameters["a"] - x ** 2 - y ** 2) * y
+            + self.parameters["omega"] * x
+            + coupling_variables["network_y"]
+            + system_input(self.noise_input_idx[1])
+            + self.parameters["ext_input_y"]
+        )
+
+        return [d_x, d_y]
+
+
+class HopfNetworkNode(Node):
+    """
+    Default Hopf normal form node with 1 neural mass modelled as Landau-Stuart
+    oscillator.
+    """
+
+    name = "Hopf normal form node"
+    label = "HopfNode"
+
+    default_network_coupling = {"network_x": 0.0, "network_y": 0.0}
+    default_output = "x"
+
+    def __init__(self, parameters=None):
+        """
+        :param parameters: parameters of the Hopf mass
+        :type parameters: dict|None
+        """
+        hopf_mass = HopfMass(parameters)
+        hopf_mass.index = 0
+        super().__init__(neural_masses=[hopf_mass])
+
+    def _sync(self):
+        return []
+
+
+class HopfNetwork(Network):
+    """
+    Whole brain network of Hopf normal form oscillators.
+    """
+
+    name = "Hopf normal form network"
+    label = "HopfNet"
+
+    sync_variables = ["network_x", "network_y"]
+
+    def __init__(
+        self, connectivity_matrix, delay_matrix, mass_parameters=None, x_coupling="diffusive", y_coupling="none",
+    ):
+        """
+        :param connectivity_matrix: connectivity matrix for between nodes
+            coupling, typically DTI structural connectivity, matrix as [from,
+            to]
+        :type connectivity_matrix: np.ndarray
+        :param delay_matrix: delay matrix between nodes, typically derived from
+            length matrix, if None, delays are all zeros, in ms, matrix as
+            [from, to]
+        :type delay_matrix: np.ndarray|None
+        :param mass_parameters: parameters for each Hopf normal form neural
+            mass, if None, will use default
+        :type mass_parameters: list[dict]|dict|None
+        :param x_coupling: how to couple `x` variables in the nodes,
+            "diffusive", "additive", or "none"
+        :type x_coupling: str
+        :param y_coupling: how to couple `y` variables in the nodes,
+            "diffusive", "additive", or "none"
+        :type y_coupling: str
+        """
+        mass_parameters = self._prepare_mass_parameters(mass_parameters, connectivity_matrix.shape[0])
+
+        nodes = []
+        for i, node_params in enumerate(mass_parameters):
+            node = HopfNetworkNode(parameters=node_params)
+            node.index = i
+            node.idx_state_var = i * node.num_state_variables
+            nodes.append(node)
+
+        super().__init__(
+            nodes=nodes, connectivity_matrix=connectivity_matrix, delay_matrix=delay_matrix,
+        )
+        # get all coupling variables
+        all_couplings = [mass.coupling_variables for node in self.nodes for mass in node.masses]
+        # assert they are the same
+        assert all(all_couplings[0] == coupling for coupling in all_couplings)
+        # invert as to name: idx
+        self.coupling_symbols = {v: k for k, v in all_couplings[0].items()}
+
+        self.x_coupling = x_coupling
+        self.y_coupling = y_coupling
+
+    def _couple(self, coupling_type, coupling_variable):
+        assert coupling_variable in self.coupling_symbols
+        if coupling_type == "additive":
+            return self._additive_coupling(self.coupling_symbols[coupling_variable], f"network_{coupling_variable}",)
+        elif coupling_type == "diffusive":
+            return self._diffusive_coupling(self.coupling_symbols[coupling_variable], f"network_{coupling_variable}",)
+        elif coupling_type == "none":
+            return self._no_coupling(f"network_{coupling_variable}")
+        else:
+            raise ValueError(f"Unknown coupling type: {coupling_type}")
+
+    def init_network(self):
+        # create symbol for each node for input
+        self.sync_symbols = {
+            f"{symbol}_{node_idx}": se.Symbol(symbol)
+            for symbol in self.sync_variables
+            for node_idx in range(self.num_nodes)
+        }
+        for node_idx, node in enumerate(self.nodes):
+            node.init_node(start_idx_for_noise=node_idx * node.num_noise_variables)
+        assert all(node.initialised for node in self)
+        self.initialised = True
+
+    def _sync(self):
+        return self._couple(self.x_coupling, "x") + self._couple(self.y_coupling, "y") + super()._sync()

--- a/neurolib/models/multimodel/builder/hopf.py
+++ b/neurolib/models/multimodel/builder/hopf.py
@@ -2,6 +2,13 @@
 Hopf normal form model.
 
 References:
+    Landau, L. D. (1944). On the problem of turbulence. In Dokl. Akad. Nauk USSR
+    (Vol. 44, p. 311).
+
+    Stuart, J. T. (1960). On the non-linear mechanics of wave disturbances in
+    stable and unstable parallel flows Part 1. The basic behaviour in plane
+    Poiseuille flow. Journal of Fluid Mechanics, 9(3), 353-370.
+
     Kuznetsov, Y. A. (2013). Elements of applied bifurcation theory (Vol. 112).
     Springer Science & Business Media.
 

--- a/neurolib/models/multimodel/builder/hopf.py
+++ b/neurolib/models/multimodel/builder/hopf.py
@@ -112,12 +112,12 @@ class HopfNetwork(Network):
     ):
         """
         :param connectivity_matrix: connectivity matrix for between nodes
-            coupling, typically DTI structural connectivity, matrix as [from,
-            to]
+            coupling, typically DTI structural connectivity, matrix as [to,
+            from]
         :type connectivity_matrix: np.ndarray
         :param delay_matrix: delay matrix between nodes, typically derived from
             length matrix, if None, delays are all zeros, in ms, matrix as
-            [from, to]
+            [to, from]
         :type delay_matrix: np.ndarray|None
         :param mass_params: parameters for each Hopf normal form neural
             mass, if None, will use default

--- a/neurolib/models/multimodel/builder/hopf.py
+++ b/neurolib/models/multimodel/builder/hopf.py
@@ -38,11 +38,11 @@ class HopfMass(NeuralMass):
     num_noise_variables = 2
     coupling_variables = {0: "x", 1: "y"}
     state_variable_names = ["x", "y"]
-    required_parameters = ["a", "omega", "ext_input_x", "ext_input_y"]
+    required_params = ["a", "omega", "ext_input_x", "ext_input_y"]
     required_couplings = ["network_x", "network_y"]
 
-    def __init__(self, parameters=None):
-        super().__init__(parameters=parameters or DEFAULT_PARAMS)
+    def __init__(self, params=None):
+        super().__init__(params=params or DEFAULT_PARAMS)
 
     def _initialize_state_vector(self):
         """
@@ -54,19 +54,19 @@ class HopfMass(NeuralMass):
         [x, y] = self._unwrap_state_vector()
 
         d_x = (
-            (self.parameters["a"] - x ** 2 - y ** 2) * x
-            - self.parameters["omega"] * y
+            (self.params["a"] - x ** 2 - y ** 2) * x
+            - self.params["omega"] * y
             + coupling_variables["network_x"]
             + system_input(self.noise_input_idx[0])
-            + self.parameters["ext_input_x"]
+            + self.params["ext_input_x"]
         )
 
         d_y = (
-            (self.parameters["a"] - x ** 2 - y ** 2) * y
-            + self.parameters["omega"] * x
+            (self.params["a"] - x ** 2 - y ** 2) * y
+            + self.params["omega"] * x
             + coupling_variables["network_y"]
             + system_input(self.noise_input_idx[1])
-            + self.parameters["ext_input_y"]
+            + self.params["ext_input_y"]
         )
 
         return [d_x, d_y]
@@ -84,12 +84,12 @@ class HopfNetworkNode(Node):
     default_network_coupling = {"network_x": 0.0, "network_y": 0.0}
     default_output = "x"
 
-    def __init__(self, parameters=None):
+    def __init__(self, params=None):
         """
-        :param parameters: parameters of the Hopf mass
-        :type parameters: dict|None
+        :param params: parameters of the Hopf mass
+        :type params: dict|None
         """
-        hopf_mass = HopfMass(parameters)
+        hopf_mass = HopfMass(params)
         hopf_mass.index = 0
         super().__init__(neural_masses=[hopf_mass])
 
@@ -108,7 +108,7 @@ class HopfNetwork(Network):
     sync_variables = ["network_x", "network_y"]
 
     def __init__(
-        self, connectivity_matrix, delay_matrix, mass_parameters=None, x_coupling="diffusive", y_coupling="none",
+        self, connectivity_matrix, delay_matrix, mass_params=None, x_coupling="diffusive", y_coupling="none",
     ):
         """
         :param connectivity_matrix: connectivity matrix for between nodes
@@ -119,9 +119,9 @@ class HopfNetwork(Network):
             length matrix, if None, delays are all zeros, in ms, matrix as
             [from, to]
         :type delay_matrix: np.ndarray|None
-        :param mass_parameters: parameters for each Hopf normal form neural
+        :param mass_params: parameters for each Hopf normal form neural
             mass, if None, will use default
-        :type mass_parameters: list[dict]|dict|None
+        :type mass_params: list[dict]|dict|None
         :param x_coupling: how to couple `x` variables in the nodes,
             "diffusive", "additive", or "none"
         :type x_coupling: str
@@ -129,11 +129,11 @@ class HopfNetwork(Network):
             "diffusive", "additive", or "none"
         :type y_coupling: str
         """
-        mass_parameters = self._prepare_mass_parameters(mass_parameters, connectivity_matrix.shape[0])
+        mass_params = self._prepare_mass_params(mass_params, connectivity_matrix.shape[0])
 
         nodes = []
-        for i, node_params in enumerate(mass_parameters):
-            node = HopfNetworkNode(parameters=node_params)
+        for i, node_params in enumerate(mass_params):
+            node = HopfNetworkNode(params=node_params)
             node.index = i
             node.idx_state_var = i * node.num_state_variables
             nodes.append(node)

--- a/neurolib/models/multimodel/builder/hopf.py
+++ b/neurolib/models/multimodel/builder/hopf.py
@@ -171,7 +171,7 @@ class HopfNetwork(Network):
     def init_network(self):
         # create symbol for each node for input
         self.sync_symbols = {
-            f"{symbol}_{node_idx}": se.Symbol(symbol)
+            f"{symbol}_{node_idx}": se.Symbol(f"{symbol}_{node_idx}")
             for symbol in self.sync_variables
             for node_idx in range(self.num_nodes)
         }

--- a/neurolib/models/multimodel/builder/hopf.py
+++ b/neurolib/models/multimodel/builder/hopf.py
@@ -12,7 +12,6 @@ References:
 """
 
 import numpy as np
-import symengine as se
 from jitcdde import input as system_input
 
 from ..builder.base.network import Network, Node
@@ -156,29 +155,6 @@ class HopfNetwork(Network):
 
         self.x_coupling = x_coupling
         self.y_coupling = y_coupling
-
-    def _couple(self, coupling_type, coupling_variable):
-        assert coupling_variable in self.coupling_symbols
-        if coupling_type == "additive":
-            return self._additive_coupling(self.coupling_symbols[coupling_variable], f"network_{coupling_variable}",)
-        elif coupling_type == "diffusive":
-            return self._diffusive_coupling(self.coupling_symbols[coupling_variable], f"network_{coupling_variable}",)
-        elif coupling_type == "none":
-            return self._no_coupling(f"network_{coupling_variable}")
-        else:
-            raise ValueError(f"Unknown coupling type: {coupling_type}")
-
-    def init_network(self):
-        # create symbol for each node for input
-        self.sync_symbols = {
-            f"{symbol}_{node_idx}": se.Symbol(f"{symbol}_{node_idx}")
-            for symbol in self.sync_variables
-            for node_idx in range(self.num_nodes)
-        }
-        for node_idx, node in enumerate(self.nodes):
-            node.init_node(start_idx_for_noise=node_idx * node.num_noise_variables)
-        assert all(node.initialised for node in self)
-        self.initialised = True
 
     def _sync(self):
         return self._couple(self.x_coupling, "x") + self._couple(self.y_coupling, "y") + super()._sync()

--- a/neurolib/models/multimodel/builder/hopf.py
+++ b/neurolib/models/multimodel/builder/hopf.py
@@ -41,14 +41,15 @@ class HopfMass(NeuralMass):
     required_params = ["a", "omega", "ext_input_x", "ext_input_y"]
     required_couplings = ["network_x", "network_y"]
 
-    def __init__(self, params=None):
-        super().__init__(params=params or DEFAULT_PARAMS)
+    def __init__(self, params=None, seed=None):
+        super().__init__(params=params or DEFAULT_PARAMS, seed=seed)
 
     def _initialize_state_vector(self):
         """
         Initialize state vector.
         """
-        self.initial_state = [0.5 * np.random.uniform(-1, 1)] * self.num_state_variables
+        np.random.seed(self.seed)
+        self.initial_state = (0.5 * np.random.uniform(-1, 1, size=(self.num_state_variables,))).tolist()
 
     def _derivatives(self, coupling_variables):
         [x, y] = self._unwrap_state_vector()
@@ -84,12 +85,14 @@ class HopfNetworkNode(Node):
     default_network_coupling = {"network_x": 0.0, "network_y": 0.0}
     default_output = "x"
 
-    def __init__(self, params=None):
+    def __init__(self, params=None, seed=None):
         """
         :param params: parameters of the Hopf mass
         :type params: dict|None
+        :param seed: seed for random number generator
+        :type seed: int|None
         """
-        hopf_mass = HopfMass(params)
+        hopf_mass = HopfMass(params, seed=seed)
         hopf_mass.index = 0
         super().__init__(neural_masses=[hopf_mass])
 
@@ -108,7 +111,7 @@ class HopfNetwork(Network):
     sync_variables = ["network_x", "network_y"]
 
     def __init__(
-        self, connectivity_matrix, delay_matrix, mass_params=None, x_coupling="diffusive", y_coupling="none",
+        self, connectivity_matrix, delay_matrix, mass_params=None, x_coupling="diffusive", y_coupling="none", seed=None,
     ):
         """
         :param connectivity_matrix: connectivity matrix for between nodes
@@ -128,12 +131,15 @@ class HopfNetwork(Network):
         :param y_coupling: how to couple `y` variables in the nodes,
             "diffusive", "additive", or "none"
         :type y_coupling: str
+        :param seed: seed for random number generator
+        :type seed: int|None
         """
         mass_params = self._prepare_mass_params(mass_params, connectivity_matrix.shape[0])
+        seeds = self._prepare_mass_params(seed, connectivity_matrix.shape[0], native_type=int)
 
         nodes = []
         for i, node_params in enumerate(mass_params):
-            node = HopfNetworkNode(params=node_params)
+            node = HopfNetworkNode(params=node_params, seed=seeds[i])
             node.index = i
             node.idx_state_var = i * node.num_state_variables
             nodes.append(node)

--- a/neurolib/models/multimodel/builder/model_input.py
+++ b/neurolib/models/multimodel/builder/model_input.py
@@ -1,0 +1,310 @@
+"""
+Handles input to neural models. Constructs both noisy and stimulation-like input
+and supports both CubicHermiteSplines for jitcdde backend and np.array for numba
+backend.
+"""
+
+import numba
+import numpy as np
+from chspy import CubicHermiteSpline
+from scipy.signal import square
+
+
+class ModelInput:
+    """
+    Generates input to neural model.
+    """
+
+    def __init__(self, duration, dt, independent_realisations=1, seed=None):
+        """
+        :param duration: duration of the input, in miliseconds
+        :type duration: float
+        :param dt: some reasonable "speed" of input, in miliseconds
+        :type dt: float
+        :param independent_realisations: how many independent realisation of
+            the input we want - for constant inputs the array is just copied,
+            for noise this means independent realisation
+        :type independent_realisations: int
+        :param seed: optional seed for noise generator
+        :type seed: int|None
+        """
+        self.times = np.arange(dt, duration + dt, dt)
+        self.dt = dt
+        self.num_iid = independent_realisations
+        # seed the generator
+        np.random.seed(seed)
+
+    def generate_input(self):
+        """
+        Function to generate input.
+        """
+        raise NotImplementedError
+
+    def as_array(self):
+        """
+        Return input as numpy array.
+        """
+        return self.generate_input()
+
+    def as_cubic_splines(self):
+        """
+        Return as cubic Hermite splines.
+        """
+        return CubicHermiteSpline.from_data(self.times, self.generate_input())
+
+
+class StimulusInput(ModelInput):
+    """
+    Generates stimulus input with optional start and end times.
+    """
+
+    def __init__(
+        self, duration, dt, stim_start=None, stim_end=None, independent_realisations=1, seed=None,
+    ):
+        """
+        :param stim_start: start of the stimulus, in miliseconds
+        :type stim_start: float
+        :param stim_end: end of the stimulus, in miliseconds
+        :type stim_end: float
+        """
+        self.stim_start = stim_start or 0.0
+        self.stim_end = stim_end or duration
+        assert self.stim_start < duration
+        assert self.stim_end <= duration
+        super().__init__(
+            duration=duration, dt=dt, independent_realisations=independent_realisations, seed=seed,
+        )
+
+    def as_array(self):
+        """
+        Return input as numpy array after checking stimulus bounds.
+        """
+        stim_input = self.generate_input()
+        stim_input[self.times < self.stim_start] = 0.0
+        stim_input[self.times > self.stim_end] = 0.0
+        return stim_input
+
+    def as_cubic_splines(self):
+        """
+        Return as cubic Hermite splines after checking stimulus bounds.
+        """
+        stim_input = self.generate_input()
+        stim_input[self.times < self.stim_start] = 0.0
+        stim_input[self.times > self.stim_end] = 0.0
+        return CubicHermiteSpline.from_data(self.times, stim_input)
+
+
+class ZeroInput(ModelInput):
+    """
+    No noise input, i.e. all zeros. For convenience.
+    """
+
+    def generate_input(self):
+        return np.zeros((self.times.shape[0], self.num_iid))
+
+
+class WienerProcess(ModelInput):
+    """
+    Basic Wiener process, dW, i.e. drawn from standard normal N(0, sqrt(dt)).
+    """
+
+    def generate_input(self):
+        return np.random.normal(0.0, np.sqrt(self.dt), (self.times.shape[0], self.num_iid))
+
+
+class OrnsteinUhlenbeckProcess(ModelInput):
+    """
+    Ornstein–Uhlenbeck process, i.e.
+        dX = (mu - X)/tau * dt + sigma*dW
+    """
+
+    def __init__(
+        self, duration, dt, mu, sigma, tau, independent_realisations=1, seed=None,
+    ):
+        """
+        :param mu: drift of the O-U process
+        :type mu: float
+        :param sigma: scale of the Wiener process
+        :type sigma: float
+        :param tau: O-U process timescale, same unit as time
+        :type tau: float
+        """
+        self.mu = mu
+        self.sigma = sigma
+        self.tau = tau
+        super().__init__(
+            duration=duration, dt=dt, independent_realisations=independent_realisations, seed=seed,
+        )
+
+    def generate_input(self):
+        x = np.random.rand(self.times.shape[0], self.num_iid) * self.mu
+        return self.numba_ou(x, self.times, self.dt, self.mu, self.sigma, self.tau, self.num_iid)
+
+    @staticmethod
+    @numba.njit()
+    def numba_ou(x, times, dt, mu, sigma, tau, num_iid):
+        """
+        Generation of Ornstein-Uhlenback process - wrapped in numba's jit for
+        speed.
+        """
+        for i in range(times.shape[0] - 1):
+            x[i + 1, :] = x[i, :] + dt * ((mu - x[i, :]) / tau) + sigma * np.sqrt(dt) * np.random.randn(num_iid)
+        return x
+
+
+class StepInput(StimulusInput):
+    """
+    Basic step process.
+    """
+
+    def __init__(
+        self, duration, dt, step_size, stim_start=None, stim_end=None, independent_realisations=1, seed=None,
+    ):
+        """
+        :param step_size: size of the stimulus
+        :type step_size: float
+        """
+        self.step_size = step_size
+        super().__init__(
+            duration=duration,
+            dt=dt,
+            stim_start=stim_start,
+            stim_end=stim_end,
+            independent_realisations=independent_realisations,
+            seed=seed,
+        )
+
+    def generate_input(self):
+        return np.ones((self.times.shape[0], self.num_iid)) * self.step_size
+
+
+class SinusoidalInput(StimulusInput):
+    """
+    Sinusoidal input.
+    """
+
+    def __init__(
+        self,
+        duration,
+        dt,
+        amplitude,
+        period,
+        nonnegative=True,
+        stim_start=None,
+        stim_end=None,
+        independent_realisations=1,
+        seed=None,
+    ):
+        """
+        :param amplitude: amplitude of the sinusoid
+        :type amplitude: float
+        :param period: period of the sinusoid, in miliseconds
+        :type period: float
+        :param nonnegative: whether the sinusoid oscillates around 0 point
+            (False), or around its amplitude, thus is nonnegative (True)
+        :type nonnegative: bool
+        """
+        self.amplitude = amplitude
+        self.period = period
+        self.nonnegative = nonnegative
+        super().__init__(
+            duration=duration,
+            dt=dt,
+            stim_start=stim_start,
+            stim_end=stim_end,
+            independent_realisations=independent_realisations,
+            seed=seed,
+        )
+
+    def generate_input(self):
+        sinusoid = self.amplitude * np.sin(2 * np.pi * self.times * (1.0 / self.period))
+        if self.nonnegative:
+            sinusoid += self.amplitude
+        return np.vstack([sinusoid] * self.num_iid).T
+
+
+class SquareInput(StimulusInput):
+    """
+    Square input.
+    """
+
+    def __init__(
+        self,
+        duration,
+        dt,
+        amplitude,
+        period,
+        nonnegative=True,
+        stim_start=None,
+        stim_end=None,
+        independent_realisations=1,
+        seed=None,
+    ):
+        """
+        :param amplitude: amplitude of the square
+        :type amplitude: float
+        :param period: period of the square, in miliseconds
+        :type period: float
+        :param nonnegative: whether the square oscillates around 0 point
+            (False), or around its amplitude, thus is nonnegative (True)
+        :type nonnegative: bool
+        """
+        self.amplitude = amplitude
+        self.period = period
+        self.nonnegative = nonnegative
+        super().__init__(
+            duration=duration,
+            dt=dt,
+            stim_start=stim_start,
+            stim_end=stim_end,
+            independent_realisations=independent_realisations,
+            seed=seed,
+        )
+
+    def generate_input(self):
+        square_inp = self.amplitude * square(2 * np.pi * self.times * (1.0 / self.period))
+        if self.nonnegative:
+            square_inp += self.amplitude
+        return np.vstack([square_inp] * self.num_iid).T
+
+
+class LinearRampInput(StimulusInput):
+    """
+    Linear ramp input.
+    """
+
+    def __init__(
+        self,
+        duration,
+        dt,
+        input_max,
+        ramp_length,
+        stim_start=None,
+        stim_end=None,
+        independent_realisations=1,
+        seed=None,
+    ):
+        """
+        :param input_max: maximum of stimulus
+        :type input_max: float
+        :param ramp_length: length of linear ramp, in miliseconds
+        :type ramp_length: float
+        """
+        self.inp_max = input_max
+        self.ramp_length = ramp_length
+        super().__init__(
+            duration=duration,
+            dt=dt,
+            stim_start=stim_start,
+            stim_end=stim_end,
+            independent_realisations=independent_realisations,
+            seed=seed,
+        )
+
+    def generate_input(self):
+        # need to adjust times for stimulus start
+        times = self.times - self.stim_start
+        linear_inp = (self.inp_max / self.ramp_length) * times * (times < self.ramp_length) + self.inp_max * (
+            times >= self.ramp_length
+        )
+        return np.vstack([linear_inp] * self.num_iid).T

--- a/neurolib/models/multimodel/builder/model_input.py
+++ b/neurolib/models/multimodel/builder/model_input.py
@@ -1,5 +1,5 @@
 """
-Handles input to neural models. Constructs both noisy and stimulation-like input
+Handles input to model. Constructs both noisy and stimulation-like input
 and supports both CubicHermiteSplines for jitcdde backend and np.array for numba
 backend.
 """
@@ -12,7 +12,7 @@ from scipy.signal import square
 
 class ModelInput:
     """
-    Generates input to neural model.
+    Generates input to model.
     """
 
     def __init__(self, duration, dt, independent_realisations=1, seed=None):

--- a/neurolib/utils/saver.py
+++ b/neurolib/utils/saver.py
@@ -2,12 +2,14 @@
 Saving model output.
 """
 
-import os
 import json
+
 import pickle
-import xarray as xr
 from copy import deepcopy
+
+import os
 import numpy as np
+import xarray as xr
 
 
 def save_to_pickle(datafield, filename):

--- a/neurolib/utils/saver.py
+++ b/neurolib/utils/saver.py
@@ -1,0 +1,81 @@
+"""
+Saving model output.
+"""
+
+import os
+import json
+import pickle
+import xarray as xr
+from copy import deepcopy
+import numpy as np
+
+
+def save_to_pickle(datafield, filename):
+    """
+    Save datafield to pickle file. Keep in mind that restoring a pickle
+    requires that the internal structure of the types for the pickled data
+    remain unchanged, o.e. not recommended for long-term storage.
+
+    :param datafield: datafield or dataarray to save
+    :type datafield: xr.Dataset|xr.DataArray
+    :param filename: filename
+    :type filename: str
+    """
+    assert isinstance(datafield, (xr.DataArray, xr.Dataset))
+    if not filename.endswith(".pkl"):
+        filename += ".pkl"
+    with open(filename, "wb") as handle:
+        pickle.dump(datafield, handle, protocol=pickle.HIGHEST_PROTOCOL)
+
+
+def save_to_netcdf(datafield, filename):
+    """
+    Save datafield to NetCDF. NetCDF cannot handle structured attributes,
+    hence they are stripped and if there are some, they are saved as json
+    with the same filename.
+
+    :param datafield: datafield or dataarray to save
+    :type datafield: xr.Dataset|xr.DataArray
+    :param filename: filename
+    :type filename: str
+    """
+    assert isinstance(datafield, (xr.DataArray, xr.Dataset))
+    datafield = deepcopy(datafield)
+    if not filename.endswith(".nc"):
+        filename += ".nc"
+    if datafield.attrs:
+        attributes_copy = deepcopy(datafield.attrs)
+        _save_attrs_json(attributes_copy, filename)
+        datafield.attrs = {}
+    datafield.to_netcdf(filename)
+
+
+def _save_attrs_json(attrs, filename):
+    """
+    Save attributes to json.
+
+    :param attrs: attributes to save
+    :type attrs: dict
+    :param filename: filename for the json file
+    :type filename: str
+    """
+
+    def sanitise_attrs(attrs):
+        sanitised = {}
+        for k, v in attrs.items():
+            if isinstance(v, list):
+                sanitised[k] = [
+                    sanitise_attrs(vv) if isinstance(vv, dict) else vv.tolist() if isinstance(vv, np.ndarray) else vv
+                    for vv in v
+                ]
+            elif isinstance(v, dict):
+                sanitised[k] = sanitise_attrs(v)
+            elif isinstance(v, np.ndarray):
+                sanitised[k] = v.tolist()
+            else:
+                sanitised[k] = v
+        return sanitised
+
+    filename = os.path.splitext(filename)[0] + ".json"
+    with open(filename, "w") as handle:
+        json.dump(sanitise_attrs(attrs), handle)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,8 @@ tqdm
 pypet
 deap
 dill
+symengine
+sympy
+git+https://github.com/neurophysik/jitcdde.git#egg=jitcdde
+chspy
+dpath

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ deap
 dill
 symengine
 sympy
-git+https://github.com/neurophysik/jitcdde.git#egg=jitcdde
+jitcdde
 chspy
 dpath

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,19 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 with open("requirements.txt") as f:
     requirements = f.read().splitlines()
 
+required = []
+dependency_links = []
+# do not add to required lines pointing to git repositories
+EGG_MARK = "#egg="
+for line in requirements:
+    if line.startswith("-e git:") or line.startswith("-e git+") or line.startswith("git:") or line.startswith("git+"):
+        assert EGG_MARK in line
+        package_name = line[line.find(EGG_MARK) + len(EGG_MARK) :]
+        required.append(package_name)
+        dependency_links.append(line)
+    else:
+        required.append(line)
+
 setuptools.setup(
     name="neurolib",
     version="0.5.6",
@@ -26,6 +39,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.6",
-    install_requires=requirements,
+    install_requires=required,
+    dependency_links=dependency_links,
     include_package_data=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -9,19 +9,6 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 with open("requirements.txt") as f:
     requirements = f.read().splitlines()
 
-required = []
-dependency_links = []
-# do not add to required lines pointing to git repositories
-EGG_MARK = "#egg="
-for line in requirements:
-    if line.startswith("-e git:") or line.startswith("-e git+") or line.startswith("git:") or line.startswith("git+"):
-        assert EGG_MARK in line
-        package_name = line[line.find(EGG_MARK) + len(EGG_MARK) :]
-        required.append(package_name)
-        dependency_links.append(line)
-    else:
-        required.append(line)
-
 setuptools.setup(
     name="neurolib",
     version="0.5.6",
@@ -39,7 +26,6 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.6",
-    install_requires=required,
-    dependency_links=dependency_links,
+    install_requires=requirements,
     include_package_data=True,
 )

--- a/tests/multimodel/base/test_backend.py
+++ b/tests/multimodel/base/test_backend.py
@@ -7,7 +7,6 @@ import pickle
 import unittest
 from shutil import rmtree
 
-import numba
 import numpy as np
 import pytest
 import symengine as se
@@ -167,12 +166,9 @@ class TestBackendIntegrator(unittest.TestCase):
     def test_run_jitcdde(self):
         system = BackendTestingHelper()
         results = system.run(
-            self.DURATION,
-            self.DT,
-            ZeroInput(self.DURATION, self.DT).as_cubic_splines(),
-            metadata=self.EXTRA_ATTRS,
-            backend="jitcdde",
+            self.DURATION, self.DT, ZeroInput(self.DURATION, self.DT).as_cubic_splines(), backend="jitcdde",
         )
+        results.attrs = self.EXTRA_ATTRS
         # assert type, length and shape of results
         self.assertTrue(isinstance(results, xr.Dataset))
         self.assertEqual(len(results), 1)
@@ -188,7 +184,6 @@ class TestBackendIntegrator(unittest.TestCase):
             self.DURATION,
             self.DT,
             ZeroInput(self.DURATION, self.DT).as_cubic_splines(),
-            metadata=self.EXTRA_ATTRS,
             backend="jitcdde",
             return_xarray=True,
         )
@@ -197,7 +192,6 @@ class TestBackendIntegrator(unittest.TestCase):
             self.DURATION,
             self.DT,
             ZeroInput(self.DURATION, self.DT).as_cubic_splines(),
-            metadata=self.EXTRA_ATTRS,
             backend="jitcdde",
             return_xarray=False,
         )
@@ -208,13 +202,8 @@ class TestBackendIntegrator(unittest.TestCase):
 
     def test_run_numba(self):
         system = BackendTestingHelper()
-        results = system.run(
-            self.DURATION,
-            self.DT,
-            ZeroInput(self.DURATION, self.DT).as_array(),
-            metadata=self.EXTRA_ATTRS,
-            backend="numba",
-        )
+        results = system.run(self.DURATION, self.DT, ZeroInput(self.DURATION, self.DT).as_array(), backend="numba",)
+        results.attrs = self.EXTRA_ATTRS
         # assert type, length and shape of results
         self.assertTrue(isinstance(results, xr.Dataset))
         self.assertEqual(len(results), 1)
@@ -230,7 +219,6 @@ class TestBackendIntegrator(unittest.TestCase):
             self.DURATION,
             self.DT,
             ZeroInput(self.DURATION, self.DT).as_cubic_splines(),
-            metadata=self.EXTRA_ATTRS,
             save_compiled_to=self.TEST_DIR,
             backend="jitcdde",
         )
@@ -241,7 +229,6 @@ class TestBackendIntegrator(unittest.TestCase):
             self.DURATION,
             self.DT,
             ZeroInput(self.DURATION, self.DT).as_cubic_splines(),
-            metadata=self.EXTRA_ATTRS,
             save_compiled_to=self.TEST_DIR,
             load_compiled=True,
         )
@@ -262,11 +249,11 @@ class TestBackendIntegrator(unittest.TestCase):
             self.DURATION,
             self.DT,
             ZeroInput(self.DURATION, self.DT).as_cubic_splines(),
-            metadata=self.EXTRA_ATTRS,
             chunksize=5,
             use_open_mp=True,
             backend="jitcdde",
         )
+        results.attrs = self.EXTRA_ATTRS
         # assert type, length and shape of results
         self.assertTrue(isinstance(results, xr.Dataset))
         self.assertEqual(len(results), 1)
@@ -283,9 +270,8 @@ class TestBackendIntegrator(unittest.TestCase):
         """
         system = BackendTestingHelper()
         # add attributes to test saving them
-        results = system.run(
-            self.DURATION, self.DT, ZeroInput(self.DURATION, self.DT).as_cubic_splines(), metadata=self.EXTRA_ATTRS,
-        )
+        results = system.run(self.DURATION, self.DT, ZeroInput(self.DURATION, self.DT).as_cubic_splines())
+        results.attrs = self.EXTRA_ATTRS
         # save to pickle
         pickle_name = os.path.join(self.TEST_DIR, "pickle_test")
         save_to_pickle(results, pickle_name)
@@ -303,9 +289,8 @@ class TestBackendIntegrator(unittest.TestCase):
         easy.
         """
         system = BackendTestingHelper()
-        results = system.run(
-            self.DURATION, self.DT, ZeroInput(self.DURATION, self.DT).as_cubic_splines(), metadata=self.EXTRA_ATTRS,
-        )
+        results = system.run(self.DURATION, self.DT, ZeroInput(self.DURATION, self.DT).as_cubic_splines())
+        results.attrs = self.EXTRA_ATTRS
         # save to pickle
         nc_name = os.path.join(self.TEST_DIR, "netcdf_test")
         save_to_netcdf(results, nc_name)

--- a/tests/multimodel/base/test_backend.py
+++ b/tests/multimodel/base/test_backend.py
@@ -8,7 +8,6 @@ import pickle
 import unittest
 from shutil import rmtree
 
-# import numba
 import numpy as np
 import pytest
 import symengine as se

--- a/tests/multimodel/base/test_backend.py
+++ b/tests/multimodel/base/test_backend.py
@@ -1,0 +1,294 @@
+"""
+Test for the backend integrator.
+"""
+
+import json
+import os
+import pickle
+import unittest
+from shutil import rmtree
+
+# import numba
+import numpy as np
+import pytest
+import symengine as se
+import xarray as xr
+from jitcdde import t as time_vector
+from jitcdde import y as state_vector
+from neurolib.models.multimodel.builder.base.backend import BackendIntegrator, BaseBackend, JitcddeBackend, NumbaBackend
+from neurolib.models.multimodel.builder.model_input import ZeroInput
+
+
+class TestBaseBackend(unittest.TestCase):
+    def test_init(self):
+        base = BaseBackend()
+        self.assertTrue(isinstance(base, BaseBackend))
+        self.assertTrue(hasattr(base, "run"))
+        self.assertTrue(hasattr(base, "clean"))
+        self.assertEqual(base._derivatives, None)
+        self.assertEqual(base._sync, None)
+        self.assertEqual(base._callbacks, None)
+        self.assertEqual(base.initial_state, None)
+        self.assertEqual(base.num_state_variables, None)
+        self.assertEqual(base.max_delay, None)
+        self.assertEqual(base.state_variable_names, None)
+        self.assertEqual(base.label, None)
+
+
+class TestJitcddeBackend(unittest.TestCase):
+    def test_init(self):
+        backend = JitcddeBackend()
+        self.assertTrue(isinstance(backend, JitcddeBackend))
+        self.assertTrue(isinstance(backend, BaseBackend))
+        self.assertTrue(hasattr(backend, "_init_and_compile_C"))
+        self.assertTrue(hasattr(backend, "_set_constant_past"))
+        self.assertTrue(hasattr(backend, "_integrate_blindly"))
+        self.assertTrue(hasattr(backend, "_check"))
+
+
+class TestNumbaBackend(unittest.TestCase):
+    def test_init(self):
+        backend = NumbaBackend()
+        self.assertTrue(isinstance(backend, NumbaBackend))
+        self.assertTrue(isinstance(backend, BaseBackend))
+        self.assertTrue(hasattr(backend, "_replace_current_ys"))
+        self.assertTrue(hasattr(backend, "_replace_past_ys"))
+        self.assertTrue(hasattr(backend, "_replace_inputs"))
+        self.assertTrue(hasattr(backend, "_substitute_helpers"))
+
+    def test_replace_current_ys(self):
+        backend = NumbaBackend()
+        STRING_IN = "0.4*(1.0*(1.0 - current_y(0))"
+        EXPECTED = "0.4*(1.0*(1.0 - y[max_delay + i - 1, 0])"
+        result = backend._replace_current_ys(STRING_IN)
+        self.assertEqual(result, EXPECTED)
+
+    def test_replace_past_ys(self):
+        backend = NumbaBackend()
+        STRING_IN = "0.06*past_y(-3.21 + t, 2, anchors(-3.21 + t)) + 0.23*" "past_y(-0.5 + t, 0, anchors(-0.5 + t))"
+        EXPECTED = "0.06*y[max_delay + i - 1 - 32, 2] + 0.23*y[max_delay + i" " - 1 - 5, 0]"
+        result = backend._replace_past_ys(STRING_IN, dt=0.1)
+        self.assertEqual(result, EXPECTED)
+
+    def test_replace_inputs(self):
+        backend = NumbaBackend()
+        STRING_IN = "12.4*past_y(-external_input + t, 3 + input_base_n, " "anchors(-external_input + t))"
+        EXPECTED = "12.4*input_y[i, 3]"
+        result = backend._replace_inputs(STRING_IN)
+        self.assertEqual(result, EXPECTED)
+
+    def test_substitute_helpers(self):
+        backend = NumbaBackend()
+        a = se.Symbol("a")
+        b = se.Symbol("b")
+        y = se.Symbol("y")
+        HELPERS = [(a, se.exp(-12 * y))]
+        DERIVATIVES = [-b * a + y, y ** 2]
+        result = backend._substitute_helpers(DERIVATIVES, HELPERS)
+        self.assertListEqual(result, [-b * se.exp(-12 * y) + y, y ** 2])
+
+    @pytest.mark.skip("currently does nothing")
+    def test_prepare_callbacks(self):
+        pass
+
+
+class BackendTestingHelper(BackendIntegrator):
+    """
+    Testing class that mimics the structure of brain models. Implements the 1D
+    Mackey-Glass delay differential equation.
+    """
+
+    label = "MackeyGlass"
+    params = {"tau": 15.0, "n": 10.0, "beta": 0.25, "gamma": 0.1}
+    initial_state = np.array([1.0])
+    num_state_variables = 1
+    max_delay = params["tau"]
+    state_variable_names = [["y"]]
+    # override initialisation
+    initialised = True
+
+    def _derivatives(self):
+        """
+        Define system's derivatives as a list.
+        """
+        return [
+            self.params["beta"]
+            * state_vector(0, time_vector - self.params["tau"])
+            / (1.0 + state_vector(0, time_vector - self.params["tau"]) ** self.params["n"])
+            - self.params["gamma"] * state_vector(0)
+        ]
+
+    def _sync(self):
+        """
+        Defines helpers - usually coupling between nodes and masses - here
+        empty.
+        """
+        return []
+
+    def _callbacks(self):
+        """
+        Defines optional python callbacks within symbolic derivatives - here
+        empty.
+        """
+        return []
+
+    def _numba_callbacks(self):
+        return []
+
+
+class TestBackendIntegrator(unittest.TestCase):
+
+    DURATION = 10000
+    DT = 10
+    here = os.path.dirname(os.path.realpath(__file__))
+    TEST_DIR = os.path.join(here, "test_temp")
+    EXTRA_ATTRS = {
+        "a": "b",
+        "c": 0.1,
+        "d": [1, 2, 3],
+        "e": np.random.rand(1, 1),
+        "f": {"aa": [np.random.rand(1, 1), np.random.rand(1, 1)], "bb": "3"},
+    }
+
+    @classmethod
+    def setUpClass(cls):
+        os.makedirs(cls.TEST_DIR, exist_ok=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        rmtree(cls.TEST_DIR, ignore_errors=True)
+
+    def test_init_system(self):
+        system = BackendTestingHelper()
+        self.assertTrue(hasattr(system, "_init_xarray"))
+        self.assertTrue(hasattr(system, "_init_backend"))
+        self.assertTrue(hasattr(system, "run"))
+
+    def test_run_jitcdde(self):
+        system = BackendTestingHelper()
+        results = system.run(
+            self.DURATION,
+            self.DT,
+            ZeroInput(self.DURATION, self.DT).as_cubic_splines(),
+            metadata=self.EXTRA_ATTRS,
+            backend="jitcdde",
+        )
+        # assert type, length and shape of results
+        self.assertTrue(isinstance(results, xr.Dataset))
+        self.assertEqual(len(results), 1)
+        self.assertTupleEqual(
+            results[system.state_variable_names[0][0]].shape, (int(self.DURATION / self.DT), 1),
+        )
+        self.assertTrue(all(dim in results.dims for dim in ["time", "node"]))
+        self.assertDictEqual(results.attrs, self.EXTRA_ATTRS)
+
+    def test_run_numba(self):
+        system = BackendTestingHelper()
+        results = system.run(
+            self.DURATION,
+            self.DT,
+            ZeroInput(self.DURATION, self.DT).as_array(),
+            metadata=self.EXTRA_ATTRS,
+            backend="numba",
+        )
+        # assert type, length and shape of results
+        self.assertTrue(isinstance(results, xr.Dataset))
+        self.assertEqual(len(results), 1)
+        self.assertTupleEqual(
+            results[system.state_variable_names[0][0]].shape, (int(self.DURATION / self.DT), 1),
+        )
+        self.assertTrue(all(dim in results.dims for dim in ["time", "node"]))
+        self.assertDictEqual(results.attrs, self.EXTRA_ATTRS)
+
+    def test_run_save_compiled(self):
+        system = BackendTestingHelper()
+        results = system.run(
+            self.DURATION,
+            self.DT,
+            ZeroInput(self.DURATION, self.DT).as_cubic_splines(),
+            metadata=self.EXTRA_ATTRS,
+            save_compiled_to=self.TEST_DIR,
+            backend="jitcdde",
+        )
+        # check the so file exists
+        self.assertTrue(os.path.exists(os.path.join(self.TEST_DIR, f"{system.label}.so")))
+        # run again but load from compiled
+        results_from_loaded = system.run(
+            self.DURATION,
+            self.DT,
+            ZeroInput(self.DURATION, self.DT).as_cubic_splines(),
+            metadata=self.EXTRA_ATTRS,
+            save_compiled_to=self.TEST_DIR,
+            load_compiled=True,
+        )
+        # check results are the same
+        self.assertEqual(results.dims, results_from_loaded.dims)
+        [
+            np.testing.assert_equal(coord1.values, coord2.values)
+            for coord1, coord2 in zip(results.coords.values(), results_from_loaded.coords.values())
+        ]
+        for data_var in results:
+            np.testing.assert_allclose(
+                results[data_var].values.astype(float), results_from_loaded[data_var].values.astype(float),
+            )
+
+    def test_run_openmp(self):
+        system = BackendTestingHelper()
+        results = system.run(
+            self.DURATION,
+            self.DT,
+            ZeroInput(self.DURATION, self.DT).as_cubic_splines(),
+            metadata=self.EXTRA_ATTRS,
+            chunksize=5,
+            use_open_mp=True,
+            backend="jitcdde",
+        )
+        # assert type, length and shape of results
+        self.assertTrue(isinstance(results, xr.Dataset))
+        self.assertEqual(len(results), 1)
+        self.assertTupleEqual(
+            results[system.state_variable_names[0][0]].shape, (int(self.DURATION / self.DT), 1),
+        )
+        self.assertTrue(all(dim in results.dims for dim in ["time", "node"]))
+        self.assertDictEqual(results.attrs, self.EXTRA_ATTRS)
+
+    def test_save_pickle(self):
+        system = BackendTestingHelper()
+        # add attributes to test saving them
+        results = system.run(
+            self.DURATION, self.DT, ZeroInput(self.DURATION, self.DT).as_cubic_splines(), metadata=self.EXTRA_ATTRS,
+        )
+        # save to pickle
+        pickle_name = os.path.join(self.TEST_DIR, "pickle_test")
+        system.save_to_pickle(results, pickle_name)
+        pickle_name += ".pkl"
+        self.assertTrue(os.path.exists(pickle_name))
+        # load and check
+        with open(pickle_name, "rb") as f:
+            loaded = pickle.load(f)
+        xr.testing.assert_equal(results, loaded)
+        self.assertDictEqual(loaded.attrs, self.EXTRA_ATTRS)
+
+    def test_save_netcdf(self):
+        system = BackendTestingHelper()
+        results = system.run(
+            self.DURATION, self.DT, ZeroInput(self.DURATION, self.DT).as_cubic_splines(), metadata=self.EXTRA_ATTRS,
+        )
+        # save to pickle
+        nc_name = os.path.join(self.TEST_DIR, "netcdf_test")
+        system.save_to_netcdf(results, nc_name)
+        # actual data
+        self.assertTrue(os.path.exists(nc_name + ".nc"))
+        # metadata
+        self.assertTrue(os.path.exists(nc_name + ".json"))
+        # load and check
+        loaded = xr.load_dataset(nc_name + ".nc")
+        with open(nc_name + ".json", "r") as f:
+            attrs = json.load(f)
+        loaded.attrs = attrs
+        xr.testing.assert_equal(results, loaded)
+        self.assertDictEqual(loaded.attrs, self.EXTRA_ATTRS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/multimodel/base/test_network.py
+++ b/tests/multimodel/base/test_network.py
@@ -1,0 +1,274 @@
+"""
+Test for network class.
+"""
+
+import unittest
+from copy import deepcopy
+
+import numpy as np
+import symengine as se
+from neurolib.models.multimodel.builder.base.constants import EXC, INH
+from neurolib.models.multimodel.builder.base.network import Network, Node, SingleCouplingExcitatoryInhibitoryNode
+from neurolib.models.multimodel.builder.base.neural_mass import NeuralMass
+
+PARAMS = {"a": 1.2, "b": 11.9}
+
+
+class ExcMassTest(NeuralMass):
+    label = EXC
+    required_parameters = ["a", "b"]
+    coupling_variables = {0: "coupling_EXC"}
+    state_variable_names = ["q"]
+    num_state_variables = 1
+    num_noise_variables = 2
+    mass_type = EXC
+
+
+class InhMassTest(NeuralMass):
+    label = INH
+    required_parameters = ["a", "b"]
+    coupling_variables = {0: "coupling_INH"}
+    state_variable_names = ["q"]
+    num_state_variables = 1
+    num_noise_variables = 2
+    mass_type = INH
+
+
+class NodeTest(Node):
+    default_output = f"q_{EXC}"
+    sync_variables = ["sync_test"]
+
+
+class SingleCouplingNodeTest(SingleCouplingExcitatoryInhibitoryNode):
+    default_output = f"q_{EXC}"
+
+
+class TestNode(unittest.TestCase):
+    def _create_node(self):
+        mass1 = ExcMassTest(PARAMS)
+        mass1.index = 0
+        mass2 = InhMassTest(PARAMS)
+        mass2.index = 1
+        node = NodeTest([mass1, mass2])
+        return node
+
+    def test_init(self):
+        node = self._create_node()
+        self.assertTrue(isinstance(node, Node))
+        self.assertEqual(len(node), 2)
+        self.assertEqual(node.num_state_variables, 2)
+        self.assertEqual(node.num_noise_variables, 4)
+        self.assertTrue(isinstance(node.__str__(), str))
+        self.assertTrue(isinstance(node.describe(), dict))
+        self.assertEqual(node.max_delay, 0.0)
+        self.assertTrue(hasattr(node, "_derivatives"))
+        self.assertTrue(hasattr(node, "_sync"))
+        self.assertTrue(hasattr(node, "_callbacks"))
+        self.assertTrue(hasattr(node, "default_output"))
+        self.assertTrue(isinstance(node.default_network_coupling, dict))
+        self.assertTrue(isinstance(node.sync_variables, list))
+
+    def test_update_parameters(self):
+        UPDATE_WITH = {"a": 2.4}
+
+        node = self._create_node()
+        node.update_parameters({"mass_0": UPDATE_WITH, "mass_1": UPDATE_WITH})
+        self.assertDictEqual({**PARAMS, **UPDATE_WITH}, node[0].parameters)
+        self.assertDictEqual({**PARAMS, **UPDATE_WITH}, node[1].parameters)
+
+    def test_strip_index(self):
+        node = self._create_node()
+        self.assertEqual(node._strip_index("test_symb_1_2"), "test_symb_1")
+
+    def test_all_couplings(self):
+        ALL_COUPLING = {0: "coupling_EXC", 1: "coupling_INH"}
+        node = self._create_node()
+        all_couplings = node.all_couplings()
+        self.assertDictEqual(all_couplings, ALL_COUPLING)
+
+    def test_init_node(self):
+        node = self._create_node()
+        node.index = 0
+        self.assertFalse(node.initialised)
+        node.init_node(start_idx_for_noise=6)
+        self.assertTrue(node.initialised)
+        self.assertTrue(isinstance(node.get_nested_parameters(), dict))
+        self.assertEqual(len(node.sync_symbols), 1)
+        self.assertTrue(all(isinstance(symb, se.Symbol) for symb in node.sync_symbols.values()))
+        np.testing.assert_equal(np.zeros((node.num_state_variables)), node.initial_state)
+        for mass in node:
+            self.assertListEqual(mass.noise_input_idx, [6, 7])
+        self.assertListEqual(node.state_variable_names, [[f"q_{EXC}", f"q_{INH}"]])
+
+
+class TestSingleCouplingExcitatoryInhibitoryNode(unittest.TestCase):
+    def _create_node(self):
+        mass1 = ExcMassTest(PARAMS)
+        mass1.index = 0
+        mass2 = InhMassTest(PARAMS)
+        mass2.index = 1
+        node = SingleCouplingNodeTest(
+            [mass1, mass2], local_connectivity=np.random.rand(2, 2), local_delays=np.array([[1.0, 2.0], [3.0, 4.0]]),
+        )
+        return node
+
+    def test_init(self):
+        node = self._create_node()
+        self.assertTrue(isinstance(node, SingleCouplingExcitatoryInhibitoryNode))
+        self.assertEqual(len(node.sync_variables), 4)
+        self.assertTrue(isinstance(node.__str__(), str))
+        self.assertTrue(isinstance(node.describe(), dict))
+        self.assertEqual(node.max_delay, 4.0)
+        self.assertEqual(np.array([0]), node.excitatory_masses)
+        self.assertEqual(np.array([1]), node.inhibitory_masses)
+
+    def test_update_parameters(self):
+        UPDATE_WITH = {"a": 2.4}
+        UPDATE_CONNECTIVITY = np.random.rand(2, 2)
+        node = self._create_node()
+        node.update_parameters(
+            {"mass_0": UPDATE_WITH, "mass_1": UPDATE_WITH, "local_connectivity": UPDATE_CONNECTIVITY}
+        )
+        self.assertDictEqual({**PARAMS, **UPDATE_WITH}, node[0].parameters)
+        self.assertDictEqual({**PARAMS, **UPDATE_WITH}, node[1].parameters)
+        np.testing.assert_equal(UPDATE_CONNECTIVITY, node.connectivity)
+
+    def test_init_node(self):
+        node = self._create_node()
+        node.index = 0
+        node.idx_state_var = 0
+        node.init_node()
+        self.assertEqual(len(node.sync_symbols), 4)
+        self.assertTrue(all(isinstance(symb, se.Symbol) for symb in node.sync_symbols.values()))
+        np.testing.assert_equal(np.zeros((node.num_state_variables)), node.initial_state)
+        self.assertEqual(node.inputs.shape[0], len(node))
+        self.assertEqual(len(node._sync()), 4)
+        for helper_sync in node._sync():
+            self.assertTrue(isinstance(helper_sync, tuple))
+            self.assertEqual(len(helper_sync), 2)
+            self.assertTrue(isinstance(helper_sync[0], se.Symbol))
+            self.assertTrue(isinstance(helper_sync[1], se.Mul))
+
+
+class TestNetwork(unittest.TestCase):
+    def _create_network(self):
+        mass1 = ExcMassTest(PARAMS)
+        mass1.index = 0
+        mass2 = InhMassTest(PARAMS)
+        mass2.index = 1
+        node1 = SingleCouplingNodeTest(
+            [mass1, mass2], local_connectivity=np.random.rand(2, 2), local_delays=np.array([[1.0, 2.0], [3.0, 4.0]]),
+        )
+        node1.index = 0
+        node1.idx_state_var = 0
+        node2 = deepcopy(node1)
+        node2.index = 1
+        node2.idx_state_var = node1.num_state_variables
+        net = Network([node1, node2], np.random.rand(2, 2), None,)
+        net.sync_variables = ["test"]
+        net.init_network()
+        # define subs for testing values
+        substitutions = {f"current_y({idx})": 1.0 for idx in range(net.num_state_variables)}
+
+        return net, substitutions
+
+    def test_init(self):
+        net, _ = self._create_network()
+        self.assertTrue(net.initialised)
+        self.assertTrue(isinstance(net, Network))
+        self.assertEqual(len(net), net.num_nodes)
+        self.assertTrue(isinstance(net.__str__(), str))
+        self.assertTrue(isinstance(net.describe(), dict))
+        self.assertTrue(isinstance(net.get_nested_parameters(), dict))
+        self.assertTrue(hasattr(net, "_callbacks"))
+        self.assertEqual(net.max_delay, 4.0)
+        self.assertEqual(len(net.sync_symbols), len(net.sync_variables) * net.num_nodes)
+        self.assertEqual(net.default_output, net[0].default_output)
+        self.assertEqual(net.default_output, net[1].default_output)
+
+    def test_update_parameters(self):
+        UPDATE_CONNECTIVITY = np.random.rand(2, 2)
+        UPDATE_DELAYS = np.abs(np.random.rand(2, 2))
+        net, _ = self._create_network()
+        net.update_parameters({"connectivity": UPDATE_CONNECTIVITY, "delays": UPDATE_DELAYS})
+        np.testing.assert_equal(net.connectivity, UPDATE_CONNECTIVITY)
+        np.testing.assert_equal(net.delays, UPDATE_DELAYS)
+
+    def test_prepare_mass_parameters(self):
+        net, _ = self._create_network()
+        # dict
+        dict_params = net._prepare_mass_parameters({"a": 3}, num_nodes=len(net), native_type=dict)
+        self.assertListEqual(dict_params, [{"a": 3}, {"a": 3}])
+        # arrays
+        array = np.random.rand(4, 4)
+        array_params = net._prepare_mass_parameters(array, num_nodes=len(net), native_type=np.ndarray)
+        self.assertListEqual(array_params, [array] * len(net))
+
+    def test_strip_index(self):
+        net, _ = self._create_network()
+        self.assertEqual(net._strip_index("test_symb_1_2"), "test_symb_1")
+        self.assertEqual(net._strip_node_idx("test_symb_1_2"), 2)
+
+    def test_input_mat(self):
+        net, _ = self._create_network()
+        input_mat = net._construct_input_matrix(0)
+        self.assertTupleEqual(input_mat.shape, (net.num_nodes, net.num_nodes))
+        self.assertTrue(all(isinstance(coupling, se.Function) for coupling in input_mat.flatten()))
+
+    def test_no_coupling(self):
+        net, _ = self._create_network()
+        no_coupling = net._no_coupling(net.sync_variables[0])
+        self.assertEqual(len(no_coupling), net.num_nodes)
+        for coupling in no_coupling:
+            self.assertTrue(isinstance(coupling, tuple))
+            self.assertEqual(len(coupling), 2)
+            self.assertTrue(isinstance(coupling[0], se.Symbol))
+            self.assertEqual(coupling[1], 0.0)
+
+    def test_diffusive_coupling(self):
+        net, subs = self._create_network()
+        diff_coupling = net._diffusive_coupling(0, net.sync_variables[0])
+        self.assertEqual(len(diff_coupling), net.num_nodes)
+        for coupling in diff_coupling:
+            self.assertTrue(isinstance(coupling, tuple))
+            self.assertEqual(len(coupling), 2)
+            self.assertTrue(isinstance(coupling[0], se.Symbol))
+            self.assertTrue(isinstance(coupling[1], se.Mul))
+            evaluated = se.sympify(coupling[1]).subs(subs)
+            self.assertEqual(float(evaluated), 0.0)
+
+    def test_additive_coupling(self):
+        net, subs = self._create_network()
+        add_coupling = net._additive_coupling(0, net.sync_variables[0])
+        self.assertEqual(len(add_coupling), net.num_nodes)
+        for i, coupling in enumerate(add_coupling):
+            self.assertTrue(isinstance(coupling, tuple))
+            self.assertEqual(len(coupling), 2)
+            self.assertTrue(isinstance(coupling[0], se.Symbol))
+            self.assertTrue(isinstance(coupling[1], se.Add))
+            evaluated = se.sympify(coupling[1]).subs(subs)
+            np.testing.assert_allclose(float(evaluated), net.connectivity.sum(axis=0)[i])
+
+    def test_additive_coupling_multiplier(self):
+        MULTIPLIER = 2.4
+        net, subs = self._create_network()
+        add_coupling = net._additive_coupling(0, net.sync_variables[0], connectivity_multiplier=MULTIPLIER)
+
+        self.assertEqual(len(add_coupling), net.num_nodes)
+        for i, coupling in enumerate(add_coupling):
+            self.assertTrue(isinstance(coupling, tuple))
+            self.assertEqual(len(coupling), 2)
+            self.assertTrue(isinstance(coupling[0], se.Symbol))
+            self.assertTrue(isinstance(coupling[1], se.Add))
+            evaluated = se.sympify(coupling[1]).subs(subs)
+            np.testing.assert_allclose(
+                float(evaluated), MULTIPLIER * net.connectivity.sum(axis=0)[i],
+            )
+
+    def test_sync(self):
+        net, _ = self._create_network()
+        self.assertListEqual(net._sync(), net[0]._sync() + net[1]._sync())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/multimodel/base/test_network.py
+++ b/tests/multimodel/base/test_network.py
@@ -16,7 +16,7 @@ PARAMS = {"a": 1.2, "b": 11.9}
 
 class ExcMassTest(NeuralMass):
     label = EXC
-    required_parameters = ["a", "b"]
+    required_params = ["a", "b"]
     coupling_variables = {0: "coupling_EXC"}
     state_variable_names = ["q"]
     num_state_variables = 1
@@ -26,7 +26,7 @@ class ExcMassTest(NeuralMass):
 
 class InhMassTest(NeuralMass):
     label = INH
-    required_parameters = ["a", "b"]
+    required_params = ["a", "b"]
     coupling_variables = {0: "coupling_INH"}
     state_variable_names = ["q"]
     num_state_variables = 1
@@ -68,13 +68,13 @@ class TestNode(unittest.TestCase):
         self.assertTrue(isinstance(node.default_network_coupling, dict))
         self.assertTrue(isinstance(node.sync_variables, list))
 
-    def test_update_parameters(self):
+    def test_update_params(self):
         UPDATE_WITH = {"a": 2.4}
 
         node = self._create_node()
-        node.update_parameters({"mass_0": UPDATE_WITH, "mass_1": UPDATE_WITH})
-        self.assertDictEqual({**PARAMS, **UPDATE_WITH}, node[0].parameters)
-        self.assertDictEqual({**PARAMS, **UPDATE_WITH}, node[1].parameters)
+        node.update_params({"mass_0": UPDATE_WITH, "mass_1": UPDATE_WITH})
+        self.assertDictEqual({**PARAMS, **UPDATE_WITH}, node[0].params)
+        self.assertDictEqual({**PARAMS, **UPDATE_WITH}, node[1].params)
 
     def test_strip_index(self):
         node = self._create_node()
@@ -92,7 +92,7 @@ class TestNode(unittest.TestCase):
         self.assertFalse(node.initialised)
         node.init_node(start_idx_for_noise=6)
         self.assertTrue(node.initialised)
-        self.assertTrue(isinstance(node.get_nested_parameters(), dict))
+        self.assertTrue(isinstance(node.get_nested_params(), dict))
         self.assertEqual(len(node.sync_symbols), 1)
         self.assertTrue(all(isinstance(symb, se.Symbol) for symb in node.sync_symbols.values()))
         np.testing.assert_equal(np.zeros((node.num_state_variables)), node.initial_state)
@@ -122,15 +122,13 @@ class TestSingleCouplingExcitatoryInhibitoryNode(unittest.TestCase):
         self.assertEqual(np.array([0]), node.excitatory_masses)
         self.assertEqual(np.array([1]), node.inhibitory_masses)
 
-    def test_update_parameters(self):
+    def test_update_params(self):
         UPDATE_WITH = {"a": 2.4}
         UPDATE_CONNECTIVITY = np.random.rand(2, 2)
         node = self._create_node()
-        node.update_parameters(
-            {"mass_0": UPDATE_WITH, "mass_1": UPDATE_WITH, "local_connectivity": UPDATE_CONNECTIVITY}
-        )
-        self.assertDictEqual({**PARAMS, **UPDATE_WITH}, node[0].parameters)
-        self.assertDictEqual({**PARAMS, **UPDATE_WITH}, node[1].parameters)
+        node.update_params({"mass_0": UPDATE_WITH, "mass_1": UPDATE_WITH, "local_connectivity": UPDATE_CONNECTIVITY})
+        self.assertDictEqual({**PARAMS, **UPDATE_WITH}, node[0].params)
+        self.assertDictEqual({**PARAMS, **UPDATE_WITH}, node[1].params)
         np.testing.assert_equal(UPDATE_CONNECTIVITY, node.connectivity)
 
     def test_init_node(self):
@@ -179,29 +177,29 @@ class TestNetwork(unittest.TestCase):
         self.assertEqual(len(net), net.num_nodes)
         self.assertTrue(isinstance(net.__str__(), str))
         self.assertTrue(isinstance(net.describe(), dict))
-        self.assertTrue(isinstance(net.get_nested_parameters(), dict))
+        self.assertTrue(isinstance(net.get_nested_params(), dict))
         self.assertTrue(hasattr(net, "_callbacks"))
         self.assertEqual(net.max_delay, 4.0)
         self.assertEqual(len(net.sync_symbols), len(net.sync_variables) * net.num_nodes)
         self.assertEqual(net.default_output, net[0].default_output)
         self.assertEqual(net.default_output, net[1].default_output)
 
-    def test_update_parameters(self):
+    def test_update_params(self):
         UPDATE_CONNECTIVITY = np.random.rand(2, 2)
         UPDATE_DELAYS = np.abs(np.random.rand(2, 2))
         net, _ = self._create_network()
-        net.update_parameters({"connectivity": UPDATE_CONNECTIVITY, "delays": UPDATE_DELAYS})
+        net.update_params({"connectivity": UPDATE_CONNECTIVITY, "delays": UPDATE_DELAYS})
         np.testing.assert_equal(net.connectivity, UPDATE_CONNECTIVITY)
         np.testing.assert_equal(net.delays, UPDATE_DELAYS)
 
-    def test_prepare_mass_parameters(self):
+    def test_prepare_mass_params(self):
         net, _ = self._create_network()
         # dict
-        dict_params = net._prepare_mass_parameters({"a": 3}, num_nodes=len(net), native_type=dict)
+        dict_params = net._prepare_mass_params({"a": 3}, num_nodes=len(net), native_type=dict)
         self.assertListEqual(dict_params, [{"a": 3}, {"a": 3}])
         # arrays
         array = np.random.rand(4, 4)
-        array_params = net._prepare_mass_parameters(array, num_nodes=len(net), native_type=np.ndarray)
+        array_params = net._prepare_mass_params(array, num_nodes=len(net), native_type=np.ndarray)
         self.assertListEqual(array_params, [array] * len(net))
 
     def test_strip_index(self):

--- a/tests/multimodel/base/test_network.py
+++ b/tests/multimodel/base/test_network.py
@@ -245,7 +245,7 @@ class TestNetwork(unittest.TestCase):
             self.assertTrue(isinstance(coupling[0], se.Symbol))
             self.assertTrue(isinstance(coupling[1], se.Add))
             evaluated = se.sympify(coupling[1]).subs(subs)
-            np.testing.assert_allclose(float(evaluated), net.connectivity.sum(axis=0)[i])
+            np.testing.assert_allclose(float(evaluated), net.connectivity.sum(axis=1)[i])
 
     def test_additive_coupling_multiplier(self):
         MULTIPLIER = 2.4
@@ -260,7 +260,7 @@ class TestNetwork(unittest.TestCase):
             self.assertTrue(isinstance(coupling[1], se.Add))
             evaluated = se.sympify(coupling[1]).subs(subs)
             np.testing.assert_allclose(
-                float(evaluated), MULTIPLIER * net.connectivity.sum(axis=0)[i],
+                float(evaluated), MULTIPLIER * net.connectivity.sum(axis=1)[i],
             )
 
     def test_sync(self):

--- a/tests/multimodel/base/test_neural_mass.py
+++ b/tests/multimodel/base/test_neural_mass.py
@@ -1,0 +1,73 @@
+"""
+Tests of modelling class.
+"""
+
+import unittest
+
+import symengine as se
+from neurolib.models.multimodel.builder.base.neural_mass import NeuralMass
+
+
+class MassTest(NeuralMass):
+    required_parameters = ["a", "b"]
+    num_state_variables = 1
+    num_noise_variables = 2
+    helper_variables = ["helper_test"]
+    python_callbacks = ["test_callback"]
+
+
+class TestNeuralMass(unittest.TestCase):
+
+    PARAMS = {"a": 1.2, "b": 11.9}
+
+    def test_init(self):
+        mass = MassTest(self.PARAMS)
+        self.assertTrue(isinstance(mass, NeuralMass))
+        self.assertTrue(isinstance(mass.__str__(), str))
+        self.assertTrue(isinstance(mass.describe(), dict))
+        mass._initialize_state_vector()
+        self.assertEqual(len(mass.initial_state), mass.num_state_variables)
+        self.assertTrue(hasattr(mass, "DESCRIPTION_FIELD"))
+        self.assertTrue(all(hasattr(mass, field) for field in mass.DESCRIPTION_FIELD))
+        self.assertTrue(hasattr(mass, "_derivatives"))
+        self.assertTrue(hasattr(mass, "_validate_parameters"))
+        self.assertTrue(hasattr(mass, "_validate_callbacks"))
+        self.assertTrue(hasattr(mass, "_initialize_state_vector"))
+        self.assertTrue(all(isinstance(symb, se.Symbol) for symb in mass.helper_symbols.values()))
+        # callbacks are UndefFunction for now
+        self.assertTrue(all(isinstance(callback, se.UndefFunction) for callback in mass.callback_functions.values()))
+
+    def test_validate_params(self):
+        mass = MassTest(self.PARAMS)
+        self.assertDictEqual(self.PARAMS, mass.parameters)
+
+    def test_update_params(self):
+        UPDATE_WITH = {"a": 2.4}
+
+        mass = MassTest(self.PARAMS)
+        self.assertDictEqual(self.PARAMS, mass.parameters)
+        mass.update_parameters(UPDATE_WITH)
+        self.assertDictEqual({**self.PARAMS, **UPDATE_WITH}, mass.parameters)
+
+    def test_init_mass(self):
+        mass = MassTest(self.PARAMS)
+        self.assertFalse(mass.initialised)
+        mass.index = 0
+        mass.init_mass(start_idx_for_noise=6)
+        self.assertTrue(mass.initialised)
+        self.assertListEqual(mass.initial_state, [0.0] * mass.num_state_variables)
+        self.assertListEqual(mass.noise_input_idx, [6, 7])
+
+    def test_unwrap_state_vector(self):
+        for sde_only in [True, False]:
+            mass = MassTest(self.PARAMS)
+            mass.idx_state_var = 0
+            self.assertTrue(hasattr(mass, "_unwrap_state_vector"))
+            state_vec = mass._unwrap_state_vector()
+            self.assertTrue(isinstance(state_vec, list))
+            self.assertEqual(len(state_vec), mass.num_state_variables)
+            self.assertTrue(all(isinstance(vec, se.Function) for vec in state_vec))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/multimodel/base/test_neural_mass.py
+++ b/tests/multimodel/base/test_neural_mass.py
@@ -9,7 +9,7 @@ from neurolib.models.multimodel.builder.base.neural_mass import NeuralMass
 
 
 class MassTest(NeuralMass):
-    required_parameters = ["a", "b"]
+    required_params = ["a", "b"]
     num_state_variables = 1
     num_noise_variables = 2
     helper_variables = ["helper_test"]
@@ -30,7 +30,7 @@ class TestNeuralMass(unittest.TestCase):
         self.assertTrue(hasattr(mass, "DESCRIPTION_FIELD"))
         self.assertTrue(all(hasattr(mass, field) for field in mass.DESCRIPTION_FIELD))
         self.assertTrue(hasattr(mass, "_derivatives"))
-        self.assertTrue(hasattr(mass, "_validate_parameters"))
+        self.assertTrue(hasattr(mass, "_validate_params"))
         self.assertTrue(hasattr(mass, "_validate_callbacks"))
         self.assertTrue(hasattr(mass, "_initialize_state_vector"))
         self.assertTrue(all(isinstance(symb, se.Symbol) for symb in mass.helper_symbols.values()))
@@ -39,15 +39,15 @@ class TestNeuralMass(unittest.TestCase):
 
     def test_validate_params(self):
         mass = MassTest(self.PARAMS)
-        self.assertDictEqual(self.PARAMS, mass.parameters)
+        self.assertDictEqual(self.PARAMS, mass.params)
 
     def test_update_params(self):
         UPDATE_WITH = {"a": 2.4}
 
         mass = MassTest(self.PARAMS)
-        self.assertDictEqual(self.PARAMS, mass.parameters)
-        mass.update_parameters(UPDATE_WITH)
-        self.assertDictEqual({**self.PARAMS, **UPDATE_WITH}, mass.parameters)
+        self.assertDictEqual(self.PARAMS, mass.params)
+        mass.update_params(UPDATE_WITH)
+        self.assertDictEqual({**self.PARAMS, **UPDATE_WITH}, mass.params)
 
     def test_init_mass(self):
         mass = MassTest(self.PARAMS)

--- a/tests/multimodel/test_hopf.py
+++ b/tests/multimodel/test_hopf.py
@@ -2,9 +2,9 @@
 Set of tests for Hopf normal form model.
 """
 import unittest
+
 import numba
 import numpy as np
-import pytest
 import xarray as xr
 from jitcdde import jitcdde_input
 from neurolib.models.hopf import HopfModel

--- a/tests/multimodel/test_hopf.py
+++ b/tests/multimodel/test_hopf.py
@@ -43,7 +43,7 @@ class TestHopfMass(MassTestCase):
     def test_init(self):
         hopf = self._create_mass()
         self.assertTrue(isinstance(hopf, HopfMass))
-        self.assertDictEqual(hopf.parameters, DEFAULT_PARAMS)
+        self.assertDictEqual(hopf.params, DEFAULT_PARAMS)
         coupling_variables = {k: 0.0 for k in hopf.required_couplings}
         self.assertEqual(len(hopf._derivatives(coupling_variables)), hopf.num_state_variables)
         self.assertEqual(len(hopf.initial_state), hopf.num_state_variables)
@@ -68,7 +68,7 @@ class TestHopfNetworkNode(unittest.TestCase):
         hopf = self._create_node()
         self.assertTrue(isinstance(hopf, HopfNetworkNode))
         self.assertEqual(len(hopf), 1)
-        self.assertDictEqual(hopf[0].parameters, DEFAULT_PARAMS)
+        self.assertDictEqual(hopf[0].params, DEFAULT_PARAMS)
         self.assertEqual(len(hopf.default_network_coupling), 2)
         np.testing.assert_equal(np.array(hopf[0].initial_state), hopf.initial_state)
 

--- a/tests/multimodel/test_hopf.py
+++ b/tests/multimodel/test_hopf.py
@@ -3,7 +3,6 @@ Set of tests for Hopf normal form model.
 """
 import unittest
 
-import numba
 import numpy as np
 import xarray as xr
 from jitcdde import jitcdde_input
@@ -102,7 +101,7 @@ class TestHopfNetworkNode(unittest.TestCase):
         """
         # run this model
         hopf_multi = self._create_node()
-        multi_result = hopf_multi.run(DURATION, DT, ZeroInput(DURATION, DT).as_array(), dt=DT, backend="numba")
+        multi_result = hopf_multi.run(DURATION, DT, ZeroInput(DURATION, DT).as_array(), backend="numba")
         # run neurolib's model
         hopf_neurolib = HopfModel(seed=SEED)
         hopf_neurolib.params["duration"] = DURATION
@@ -148,7 +147,7 @@ class TestHopfNetwork(unittest.TestCase):
         """
         # run this model - default is diffusive coupling
         fhn_multi = HopfNetwork(self.SC, self.DELAYS, x_coupling="diffusive", seed=SEED)
-        multi_result = fhn_multi.run(DURATION, DT, ZeroInput(DURATION, DT).as_array(), dt=DT, backend="numba")
+        multi_result = fhn_multi.run(DURATION, DT, ZeroInput(DURATION, DT).as_array(), backend="numba")
         # run neurolib's model
         fhn_neurolib = HopfModel(Cmat=self.SC, Dmat=self.DELAYS, seed=SEED)
         fhn_neurolib.params["duration"] = DURATION

--- a/tests/multimodel/test_hopf.py
+++ b/tests/multimodel/test_hopf.py
@@ -1,0 +1,128 @@
+"""
+Set of tests for Hopf normal form model.
+"""
+
+import unittest
+
+import numpy as np
+import xarray as xr
+from jitcdde import jitcdde_input
+from neurolib.models.multimodel.builder.hopf import DEFAULT_PARAMS, HopfMass, HopfNetwork, HopfNetworkNode
+from neurolib.models.multimodel.builder.model_input import ZeroInput
+
+DURATION = 100.0
+DT = 0.1
+CORR_THRESHOLD = 0.99
+
+# dictionary as backend name: format in which the noise is passed
+BACKENDS_TO_TEST = {
+    "jitcdde": lambda x: x.as_cubic_splines(),
+    "numba": lambda x: x.as_array(),
+}
+
+
+class MassTestCase(unittest.TestCase):
+    def _run_node(self, node, duration, dt):
+        coupling_variables = {k: 0.0 for k in node.required_couplings}
+        noise = ZeroInput(duration, dt, independent_realisations=node.num_noise_variables).as_cubic_splines()
+        system = jitcdde_input(node._derivatives(coupling_variables), input=noise)
+        system.constant_past(np.array(node.initial_state))
+        system.adjust_diff()
+        times = np.arange(dt, duration + dt, dt)
+        return np.vstack([system.integrate(time) for time in times])
+
+
+class TestHopfMass(MassTestCase):
+    def _create_mass(self):
+        hopf = HopfMass()
+        hopf.index = 0
+        hopf.idx_state_var = 0
+        hopf.init_mass()
+        return hopf
+
+    def test_init(self):
+        hopf = self._create_mass()
+        self.assertTrue(isinstance(hopf, HopfMass))
+        self.assertDictEqual(hopf.parameters, DEFAULT_PARAMS)
+        coupling_variables = {k: 0.0 for k in hopf.required_couplings}
+        self.assertEqual(len(hopf._derivatives(coupling_variables)), hopf.num_state_variables)
+        self.assertEqual(len(hopf.initial_state), hopf.num_state_variables)
+        self.assertEqual(len(hopf.noise_input_idx), hopf.num_noise_variables)
+
+    def test_run(self):
+        hopf = self._create_mass()
+        result = self._run_node(hopf, DURATION, DT)
+        self.assertTrue(isinstance(result, np.ndarray))
+        self.assertTupleEqual(result.shape, (int(DURATION / DT), hopf.num_state_variables))
+
+
+class TestHopfNetworkNode(unittest.TestCase):
+    def _create_node(self):
+        node = HopfNetworkNode()
+        node.index = 0
+        node.idx_state_var = 0
+        node.init_node()
+        return node
+
+    def test_init(self):
+        hopf = self._create_node()
+        self.assertTrue(isinstance(hopf, HopfNetworkNode))
+        self.assertEqual(len(hopf), 1)
+        self.assertDictEqual(hopf[0].parameters, DEFAULT_PARAMS)
+        self.assertEqual(len(hopf.default_network_coupling), 2)
+        np.testing.assert_equal(np.array(hopf[0].initial_state), hopf.initial_state)
+
+    def test_run(self):
+        hopf = self._create_node()
+        all_results = []
+        for backend, noise_func in BACKENDS_TO_TEST.items():
+            result = hopf.run(
+                DURATION, DT, noise_func(ZeroInput(DURATION, DT, hopf.num_noise_variables)), backend=backend,
+            )
+            self.assertTrue(isinstance(result, xr.Dataset))
+            self.assertEqual(len(result), hopf.num_state_variables)
+            self.assertTrue(all(state_var in result for state_var in hopf.state_variable_names[0]))
+            self.assertTrue(
+                all(result[state_var].shape == (int(DURATION / DT), 1) for state_var in hopf.state_variable_names[0])
+            )
+            all_results.append(result)
+        # test results are the same from different backends
+        for state_var in all_results[0]:
+            corr_mat = np.corrcoef(
+                np.vstack([result[state_var].values.flatten().astype(float) for result in all_results])
+            )
+            self.assertTrue(np.greater(corr_mat, CORR_THRESHOLD).all())
+
+
+class TestHopfNetwork(unittest.TestCase):
+    SC = np.random.rand(2, 2)
+    DELAYS = np.array([[1.0, 2.0], [2.0, 1.0]])
+
+    def test_init(self):
+        hopf = HopfNetwork(self.SC, self.DELAYS)
+        self.assertTrue(isinstance(hopf, HopfNetwork))
+        self.assertEqual(len(hopf), self.SC.shape[0])
+        self.assertEqual(hopf.initial_state.shape[0], hopf.num_state_variables)
+        self.assertEqual(hopf.default_output, "x")
+
+    def test_run(self):
+        hopf = HopfNetwork(self.SC, self.DELAYS)
+        all_results = []
+        for backend, noise_func in BACKENDS_TO_TEST.items():
+            result = hopf.run(
+                DURATION, DT, noise_func(ZeroInput(DURATION, DT, hopf.num_noise_variables)), backend=backend,
+            )
+            self.assertTrue(isinstance(result, xr.Dataset))
+            self.assertEqual(len(result), hopf.num_state_variables / hopf.num_nodes)
+            self.assertTrue(all(result[result_].shape == (int(DURATION / DT), hopf.num_nodes) for result_ in result))
+        all_results.append(result)
+        # test results are the same from different backends
+        for state_var in all_results[0]:
+            corr_mat = np.corrcoef(
+                np.vstack([result[state_var].values.flatten().astype(float) for result in all_results])
+            )
+            self.assertTrue(np.greater(corr_mat, CORR_THRESHOLD).all())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/multimodel/test_model_input.py
+++ b/tests/multimodel/test_model_input.py
@@ -1,0 +1,184 @@
+"""
+Tests of noise input.
+"""
+
+import unittest
+
+import numpy as np
+from chspy import CubicHermiteSpline
+
+from neurolib.models.multimodel.builder.model_input import (
+    LinearRampInput,
+    OrnsteinUhlenbeckProcess,
+    SinusoidalInput,
+    SquareInput,
+    StepInput,
+    WienerProcess,
+    ZeroInput,
+)
+
+TESTING_TIME = 5.3
+DURATION = 10
+DT = 0.1
+STIM_START = 2
+STIM_END = 8
+SHAPE = (int(DURATION / DT), 2)
+
+
+class TestCubicSplines(unittest.TestCase):
+    RESULT_SPLINES = np.array([-0.05100302, 0.1277721])
+    RESULT_ARRAY = np.array([0.59646435, 0.05520635])
+
+    def test_splines(self):
+        dW = WienerProcess(duration=DURATION, dt=DT, independent_realisations=2, seed=42).as_cubic_splines()
+        self.assertTrue(isinstance(dW, CubicHermiteSpline))
+        np.testing.assert_allclose(self.RESULT_SPLINES, dW.get_state(TESTING_TIME))
+
+    def test_arrays(self):
+        dW = WienerProcess(duration=DURATION, dt=DT, independent_realisations=2, seed=42).as_array()
+        self.assertTrue(isinstance(dW, np.ndarray))
+        time_idx = np.around(TESTING_TIME / DT).astype(int)
+        np.testing.assert_allclose(self.RESULT_ARRAY, dW[time_idx, :])
+
+
+class TestZeroInput(unittest.TestCase):
+    def test_generate_input(self):
+        nn = ZeroInput(duration=DURATION, dt=DT, independent_realisations=2, seed=42).generate_input()
+        self.assertTrue(isinstance(nn, np.ndarray))
+        self.assertTupleEqual(nn.shape, SHAPE)
+        np.testing.assert_allclose(nn, np.zeros(SHAPE))
+
+
+class TestWienerProcess(unittest.TestCase):
+    def test_generate_input(self):
+        dW = WienerProcess(duration=DURATION, dt=DT, independent_realisations=2, seed=42).generate_input()
+        self.assertTrue(isinstance(dW, np.ndarray))
+        self.assertTupleEqual(dW.shape, SHAPE)
+
+
+class TestOrnsteinUhlenbeckProcess(unittest.TestCase):
+    def test_generate_input(self):
+        ou = OrnsteinUhlenbeckProcess(
+            duration=DURATION, dt=DT, mu=3.0, sigma=0.1, tau=2 * DT, independent_realisations=2, seed=42,
+        ).generate_input()
+        self.assertTrue(isinstance(ou, np.ndarray))
+        self.assertTupleEqual(ou.shape, SHAPE)
+
+
+class TestStepInput(unittest.TestCase):
+    STEP_SIZE = 2.3
+
+    def test_generate_input(self):
+        step = StepInput(
+            duration=DURATION, dt=DT, step_size=self.STEP_SIZE, independent_realisations=2, seed=42,
+        ).generate_input()
+        self.assertTrue(isinstance(step, np.ndarray))
+        self.assertTupleEqual(step.shape, SHAPE)
+        np.testing.assert_allclose(step, self.STEP_SIZE)
+
+    def test_start_end_input(self):
+        step = StepInput(
+            duration=DURATION,
+            dt=DT,
+            stim_start=STIM_START,
+            stim_end=STIM_END,
+            step_size=self.STEP_SIZE,
+            independent_realisations=2,
+            seed=42,
+        ).as_array()
+        np.testing.assert_allclose(step[: int(STIM_START / DT) - 1, :], 0.0)
+        np.testing.assert_allclose(step[int(STIM_END / DT) :, :], 0.0)
+
+
+class TestSinusoidalInput(unittest.TestCase):
+    AMPLITUDE = 2.3
+    PERIOD = 2.0
+
+    def test_generate_input(self):
+
+        sin = SinusoidalInput(
+            duration=DURATION, dt=DT, amplitude=self.AMPLITUDE, period=self.PERIOD, independent_realisations=2, seed=42,
+        ).generate_input()
+        self.assertTrue(isinstance(sin, np.ndarray))
+        self.assertTupleEqual(sin.shape, SHAPE)
+        np.testing.assert_equal(np.mean(sin, axis=0), np.array(2 * [self.AMPLITUDE]))
+
+    def test_start_end_input(self):
+        sin = SinusoidalInput(
+            duration=DURATION,
+            dt=DT,
+            stim_start=STIM_START,
+            stim_end=STIM_END,
+            amplitude=self.AMPLITUDE,
+            period=self.PERIOD,
+            independent_realisations=2,
+            seed=42,
+        ).as_array()
+        np.testing.assert_allclose(sin[: int(STIM_START / DT) - 1, :], 0.0)
+        np.testing.assert_allclose(sin[int(STIM_END / DT) :, :], 0.0)
+
+
+class TestSquareInput(unittest.TestCase):
+    AMPLITUDE = 2.3
+    PERIOD = 2.0
+
+    def test_generate_input(self):
+
+        sq = SquareInput(
+            duration=DURATION, dt=DT, amplitude=self.AMPLITUDE, period=self.PERIOD, independent_realisations=2, seed=42,
+        ).generate_input()
+        self.assertTrue(isinstance(sq, np.ndarray))
+        self.assertTupleEqual(sq.shape, SHAPE)
+        np.testing.assert_equal(np.mean(sq, axis=0), np.array(2 * [self.AMPLITUDE]))
+
+    def test_start_end_input(self):
+        sq = SquareInput(
+            duration=DURATION,
+            dt=DT,
+            stim_start=STIM_START,
+            stim_end=STIM_END,
+            amplitude=self.AMPLITUDE,
+            period=self.PERIOD,
+            independent_realisations=2,
+            seed=42,
+        ).as_array()
+        np.testing.assert_allclose(sq[: int(STIM_START / DT) - 1, :], 0.0)
+        np.testing.assert_allclose(sq[int(STIM_END / DT) :, :], 0.0)
+
+
+class TestLinearRampInput(unittest.TestCase):
+    INP_MAX = 5.0
+    RAMP_LENGTH = 2.0
+
+    def test_generate_input(self):
+
+        ramp = LinearRampInput(
+            duration=DURATION,
+            dt=DT,
+            input_max=self.INP_MAX,
+            ramp_length=self.RAMP_LENGTH,
+            independent_realisations=2,
+            seed=42,
+        ).generate_input()
+        self.assertTrue(isinstance(ramp, np.ndarray))
+        self.assertTupleEqual(ramp.shape, SHAPE)
+        np.testing.assert_equal(np.max(ramp, axis=0), np.array(2 * [self.INP_MAX]))
+        np.testing.assert_equal(np.min(ramp, axis=0), np.array(2 * [0.25]))
+
+    def test_start_end_input(self):
+        ramp = LinearRampInput(
+            duration=DURATION,
+            dt=DT,
+            stim_start=STIM_START,
+            stim_end=STIM_END,
+            input_max=self.INP_MAX,
+            ramp_length=self.RAMP_LENGTH,
+            independent_realisations=2,
+            seed=42,
+        ).as_array()
+        np.testing.assert_allclose(ramp[: int(STIM_START / DT) - 1, :], 0.0)
+        np.testing.assert_allclose(ramp[int(STIM_END / DT) :, :], 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR contains the basic structure of MultiModels, i.e. hierarchical heterogeneous models building. 
Includes:
* base classes for three levels of hierarchy (`NeuralMass`, `Node`, `Network`) - of course the names are negotiable :)
* backend integrator (both `jitcdde`-based with adaptive `dt` and `numba` with Euler scheme)
* model input - for adding noise or stimuli to the models
* Hopf model - as an example of how various parts of the framework work together
* tests for all of the above written
* added packages to requirements
* altered `setup.py` - one package needs to be installed from github as the newest additions I am using are not tagged yet, hence not on `pypi` - this will change in the future I hope

I suggest the following order of review:
1. `multimodel/builder/base/neural_mass.py` - so you know how the basic dynamics is defined
2. `multimodel/builder/base/network.py`  - how the basic building blocks are connected
3. `multimodel/builder/hopf.py` - example of very simple model - how to connect all the dots
4. `multimodel/builder/model_input.py` - how the input is passed to the model (both noise or stimulus)
5. `multimodel/builder/base/backend.py` - how the integration is done
6. all the tests

I realise this is way too many lines - but part of it is my comments. I tried to comment heavily directly in the code so it's clear what, how and when.
Of course, you can take as much time as you need.

As of now, there is no functional connection to `neurolib`'s core - this will follow.
What will follow:
* PR2: all other models except AdEx, i.e. Wilson-Cowan, FitzHugh-Nagumo, thalamic mass model and Wong-Wang
* PR3: AdEx as this one is a bit complicated since it involves table lookup
* PR4: connection of all this to `neurolib`s core

P.S: I will comment directly to this PR for things I believe they deserve more comments
