### PR TITLE
MultiModel PR2: base models

### DIFF
--- a/neurolib/models/multimodel/builder/fitzhugh_nagumo.py
+++ b/neurolib/models/multimodel/builder/fitzhugh_nagumo.py
@@ -128,8 +128,7 @@ class FitzHughNagumoNetwork(Network):
 
     sync_variables = ["network_x", "network_y"]
     # define default coupling in FitzHugh-Nagumo network
-    x_coupling = "diffusive"
-    y_coupling = "none"
+    default_coupling = {"network_x": "diffusive", "network_y": "none"}
 
     def __init__(
         self, connectivity_matrix, delay_matrix, mass_params=None, seed=None,
@@ -169,6 +168,3 @@ class FitzHughNagumoNetwork(Network):
         assert all(all_couplings[0] == coupling for coupling in all_couplings)
         # invert as to name: idx
         self.coupling_symbols = {v: k for k, v in all_couplings[0].items()}
-
-    def _sync(self):
-        return self._couple(self.x_coupling, "x") + self._couple(self.y_coupling, "y") + super()._sync()

--- a/neurolib/models/multimodel/builder/fitzhugh_nagumo.py
+++ b/neurolib/models/multimodel/builder/fitzhugh_nagumo.py
@@ -47,7 +47,7 @@ class FitzHughNagumoMass(NeuralMass):
     num_noise_variables = 2
     coupling_variables = {0: "x", 1: "y"}
     state_variable_names = ["x", "y"]
-    required_parameters = [
+    required_params = [
         "alpha",
         "beta",
         "gamma",
@@ -59,8 +59,8 @@ class FitzHughNagumoMass(NeuralMass):
     ]
     required_couplings = ["network_x", "network_y"]
 
-    def __init__(self, parameters=None):
-        super().__init__(parameters=parameters or DEFAULT_PARAMS)
+    def __init__(self, params=None):
+        super().__init__(params=params or DEFAULT_PARAMS)
 
     def _initialize_state_vector(self):
         """
@@ -72,20 +72,20 @@ class FitzHughNagumoMass(NeuralMass):
         [x, y] = self._unwrap_state_vector()
 
         d_x = (
-            -self.parameters["alpha"] * x ** 3
-            + self.parameters["beta"] * x ** 2
-            + self.parameters["gamma"] * x
+            -self.params["alpha"] * x ** 3
+            + self.params["beta"] * x ** 2
+            + self.params["gamma"] * x
             - y
             + coupling_variables["network_x"]
             + system_input(self.noise_input_idx[0])
-            + self.parameters["ext_input_x"]
+            + self.params["ext_input_x"]
         )
 
         d_y = (
-            (x - self.parameters["delta"] - self.parameters["epsilon"] * y) / self.parameters["tau"]
+            (x - self.params["delta"] - self.params["epsilon"] * y) / self.params["tau"]
             + coupling_variables["network_y"]
             + system_input(self.noise_input_idx[1])
-            + self.parameters["ext_input_y"]
+            + self.params["ext_input_y"]
         )
 
         return [d_x, d_y]
@@ -103,12 +103,12 @@ class FitzHughNagumoNetworkNode(Node):
     default_network_coupling = {"network_x": 0.0, "network_y": 0.0}
     default_output = "x"
 
-    def __init__(self, parameters=None):
+    def __init__(self, params=None):
         """
-        :param parameters: parameters of the FitzHugh-Nagumo mass
-        :type parameters: dict|None
+        :param params: parameters of the FitzHugh-Nagumo mass
+        :type params: dict|None
         """
-        fhn_mass = FitzHughNagumoMass(parameters)
+        fhn_mass = FitzHughNagumoMass(params)
         fhn_mass.index = 0
         super().__init__(neural_masses=[fhn_mass])
 
@@ -127,7 +127,7 @@ class FitzHughNagumoNetwork(Network):
     sync_variables = ["network_x", "network_y"]
 
     def __init__(
-        self, connectivity_matrix, delay_matrix, mass_parameters=None, x_coupling="diffusive", y_coupling="none",
+        self, connectivity_matrix, delay_matrix, mass_params=None, x_coupling="diffusive", y_coupling="none",
     ):
         """
         :param connectivity_matrix: connectivity matrix for between nodes
@@ -138,9 +138,9 @@ class FitzHughNagumoNetwork(Network):
             length matrix, if None, delays are all zeros, in ms, matrix as
             [to, from]
         :type delay_matrix: np.ndarray|None
-        :param mass_parameters: parameters for each Hopf normal form neural
+        :param mass_params: parameters for each Hopf normal form neural
             mass, if None, will use default
-        :type mass_parameters: list[dict]|dict|None
+        :type mass_params: list[dict]|dict|None
         :param x_coupling: how to couple `x` variables in the nodes,
             "diffusive", "additive", or "none"
         :type x_coupling: str
@@ -148,11 +148,11 @@ class FitzHughNagumoNetwork(Network):
             "diffusive", "additive", or "none"
         :type y_coupling: str
         """
-        mass_parameters = self._prepare_mass_parameters(mass_parameters, connectivity_matrix.shape[0])
+        mass_params = self._prepare_mass_params(mass_params, connectivity_matrix.shape[0])
 
         nodes = []
-        for i, node_params in enumerate(mass_parameters):
-            node = FitzHughNagumoNetworkNode(parameters=node_params)
+        for i, node_params in enumerate(mass_params):
+            node = FitzHughNagumoNetworkNode(params=node_params)
             node.index = i
             node.idx_state_var = i * node.num_state_variables
             nodes.append(node)

--- a/neurolib/models/multimodel/builder/fitzhugh_nagumo.py
+++ b/neurolib/models/multimodel/builder/fitzhugh_nagumo.py
@@ -1,0 +1,197 @@
+"""
+FitzHugh–Nagumo model.
+
+Main references:
+    FitzHugh, R. (1955). Mathematical models of threshold phenomena in the
+    nerve membrane. The bulletin of mathematical biophysics, 17(4), 257-278.
+
+    Nagumo, J., Arimoto, S., & Yoshizawa, S. (1962). An active pulse
+    transmission line simulating nerve axon. Proceedings of the IRE, 50(10),
+    2061-2070.
+
+Additional reference:
+    Kostova, T., Ravindran, R., & Schonbek, M. (2004). FitzHugh–Nagumo
+    revisited: Types of bifurcations, periodical forcing and stability regions
+    by a Lyapunov functional. International journal of bifurcation and chaos,
+    14(03), 913-925.
+"""
+
+import numpy as np
+import symengine as se
+from jitcdde import input as system_input
+
+from ..builder.base.network import Network, Node
+from ..builder.base.neural_mass import NeuralMass
+
+DEFAULT_PARAMS = {
+    "alpha": 3.0,
+    "beta": 4.0,
+    "gamma": -1.5,
+    "delta": 0.0,
+    "epsilon": 0.5,
+    "tau": 20.0,
+    "ext_input_x": 1.0,
+    "ext_input_y": 0.0,
+}
+
+
+class FitzHughNagumoMass(NeuralMass):
+    """
+    FitzHugh-Nagumo neural mass.
+    """
+
+    name = "FitzHugh-Nagumo mass"
+    label = "FHNmass"
+
+    num_state_variables = 2
+    num_noise_variables = 2
+    coupling_variables = {0: "x", 1: "y"}
+    state_variable_names = ["x", "y"]
+    required_parameters = [
+        "alpha",
+        "beta",
+        "gamma",
+        "delta",
+        "epsilon",
+        "tau",
+        "ext_input_x",
+        "ext_input_y",
+    ]
+    required_couplings = ["network_x", "network_y"]
+
+    def __init__(self, parameters=None):
+        super().__init__(parameters=parameters or DEFAULT_PARAMS)
+
+    def _initialize_state_vector(self):
+        """
+        Initialize state vector.
+        """
+        self.initial_state = [0.05 * np.random.uniform(0, 1)] * self.num_state_variables
+
+    def _derivatives(self, coupling_variables):
+        [x, y] = self._unwrap_state_vector()
+
+        d_x = (
+            -self.parameters["alpha"] * x ** 3
+            + self.parameters["beta"] * x ** 2
+            + self.parameters["gamma"] * x
+            - y
+            + coupling_variables["network_x"]
+            + system_input(self.noise_input_idx[0])
+            + self.parameters["ext_input_x"]
+        )
+
+        d_y = (
+            (x - self.parameters["delta"] - self.parameters["epsilon"] * y) / self.parameters["tau"]
+            + coupling_variables["network_y"]
+            + system_input(self.noise_input_idx[1])
+            + self.parameters["ext_input_y"]
+        )
+
+        return [d_x, d_y]
+
+
+class FitzHughNagumoNetworkNode(Node):
+    """
+    Default FitzHugh-Nagumo node with 1 neural mass modelled as FitzHugh-Nagumo
+    oscillator.
+    """
+
+    name = "FitzHugh-Nagumo node"
+    label = "FHNnode"
+
+    default_network_coupling = {"network_x": 0.0, "network_y": 0.0}
+    default_output = "x"
+
+    def __init__(self, parameters=None):
+        """
+        :param parameters: parameters of the FitzHugh-Nagumo mass
+        :type parameters: dict|None
+        """
+        fhn_mass = FitzHughNagumoMass(parameters)
+        fhn_mass.index = 0
+        super().__init__(neural_masses=[fhn_mass])
+
+    def _sync(self):
+        return []
+
+
+class FitzHughNagumoNetwork(Network):
+    """
+    Whole brain network of FitzHugh-Nagumo oscillators.
+    """
+
+    name = "FitzHugh-Nagumo network"
+    label = "FHNnet"
+
+    sync_variables = ["network_x", "network_y"]
+
+    def __init__(
+        self, connectivity_matrix, delay_matrix, mass_parameters=None, x_coupling="diffusive", y_coupling="none",
+    ):
+        """
+        :param connectivity_matrix: connectivity matrix for between nodes
+            coupling, typically DTI structural connectivity, matrix as [to,
+            from]
+        :type connectivity_matrix: np.ndarray
+        :param delay_matrix: delay matrix between nodes, typically derived from
+            length matrix, if None, delays are all zeros, in ms, matrix as
+            [to, from]
+        :type delay_matrix: np.ndarray|None
+        :param mass_parameters: parameters for each Hopf normal form neural
+            mass, if None, will use default
+        :type mass_parameters: list[dict]|dict|None
+        :param x_coupling: how to couple `x` variables in the nodes,
+            "diffusive", "additive", or "none"
+        :type x_coupling: str
+        :param y_coupling: how to couple `y` variables in the nodes,
+            "diffusive", "additive", or "none"
+        :type y_coupling: str
+        """
+        mass_parameters = self._prepare_mass_parameters(mass_parameters, connectivity_matrix.shape[0])
+
+        nodes = []
+        for i, node_params in enumerate(mass_parameters):
+            node = FitzHughNagumoNetworkNode(parameters=node_params)
+            node.index = i
+            node.idx_state_var = i * node.num_state_variables
+            nodes.append(node)
+
+        super().__init__(
+            nodes=nodes, connectivity_matrix=connectivity_matrix, delay_matrix=delay_matrix,
+        )
+        # get all coupling variables
+        all_couplings = [mass.coupling_variables for node in self.nodes for mass in node.masses]
+        # assert they are the same
+        assert all(all_couplings[0] == coupling for coupling in all_couplings)
+        # invert as to name: idx
+        self.coupling_symbols = {v: k for k, v in all_couplings[0].items()}
+
+        self.x_coupling = x_coupling
+        self.y_coupling = y_coupling
+
+    def _couple(self, coupling_type, coupling_variable):
+        assert coupling_variable in self.coupling_symbols
+        if coupling_type == "additive":
+            return self._additive_coupling(self.coupling_symbols[coupling_variable], f"network_{coupling_variable}",)
+        elif coupling_type == "diffusive":
+            return self._diffusive_coupling(self.coupling_symbols[coupling_variable], f"network_{coupling_variable}",)
+        elif coupling_type == "none":
+            return self._no_coupling(f"network_{coupling_variable}")
+        else:
+            raise ValueError(f"Unknown coupling type: {coupling_type}")
+
+    def init_network(self):
+        # create symbol for each node for input
+        self.sync_symbols = {
+            f"{symbol}_{node_idx}": se.Symbol(symbol)
+            for symbol in self.sync_variables
+            for node_idx in range(self.num_nodes)
+        }
+        for node_idx, node in enumerate(self.nodes):
+            node.init_node(start_idx_for_noise=node_idx * node.num_noise_variables)
+        assert all(node.initialised for node in self)
+        self.initialised = True
+
+    def _sync(self):
+        return self._couple(self.x_coupling, "x") + self._couple(self.y_coupling, "y") + super()._sync()

--- a/neurolib/models/multimodel/builder/fitzhugh_nagumo.py
+++ b/neurolib/models/multimodel/builder/fitzhugh_nagumo.py
@@ -91,7 +91,7 @@ class FitzHughNagumoMass(NeuralMass):
         return [d_x, d_y]
 
 
-class FitzHughNagumoNetworkNode(Node):
+class FitzHughNagumoNode(Node):
     """
     Default FitzHugh-Nagumo node with 1 neural mass modelled as FitzHugh-Nagumo
     oscillator.
@@ -127,9 +127,12 @@ class FitzHughNagumoNetwork(Network):
     label = "FHNnet"
 
     sync_variables = ["network_x", "network_y"]
+    # define default coupling in FitzHugh-Nagumo network
+    x_coupling = "diffusive"
+    y_coupling = "none"
 
     def __init__(
-        self, connectivity_matrix, delay_matrix, mass_params=None, x_coupling="diffusive", y_coupling="none", seed=None,
+        self, connectivity_matrix, delay_matrix, mass_params=None, seed=None,
     ):
         """
         :param connectivity_matrix: connectivity matrix for between nodes
@@ -143,11 +146,6 @@ class FitzHughNagumoNetwork(Network):
         :param mass_params: parameters for each Hopf normal form neural
             mass, if None, will use default
         :type mass_params: list[dict]|dict|None
-        :param x_coupling: how to couple `x` variables in the nodes,
-            "diffusive", "additive", or "none"
-        :type x_coupling: str
-        :param y_coupling: how to couple `y` variables in the nodes,
-            "diffusive", "additive", or "none"
         :type y_coupling: str
         :param seed: seed for random number generator
         :type seed: int|None
@@ -157,7 +155,7 @@ class FitzHughNagumoNetwork(Network):
 
         nodes = []
         for i, node_params in enumerate(mass_params):
-            node = FitzHughNagumoNetworkNode(params=node_params, seed=seeds[i])
+            node = FitzHughNagumoNode(params=node_params, seed=seeds[i])
             node.index = i
             node.idx_state_var = i * node.num_state_variables
             nodes.append(node)
@@ -171,9 +169,6 @@ class FitzHughNagumoNetwork(Network):
         assert all(all_couplings[0] == coupling for coupling in all_couplings)
         # invert as to name: idx
         self.coupling_symbols = {v: k for k, v in all_couplings[0].items()}
-
-        self.x_coupling = x_coupling
-        self.y_coupling = y_coupling
 
     def _sync(self):
         return self._couple(self.x_coupling, "x") + self._couple(self.y_coupling, "y") + super()._sync()

--- a/neurolib/models/multimodel/builder/hopf.py
+++ b/neurolib/models/multimodel/builder/hopf.py
@@ -116,8 +116,7 @@ class HopfNetwork(Network):
 
     sync_variables = ["network_x", "network_y"]
     # define default coupling in Hopf network
-    x_coupling = "diffusive"
-    y_coupling = "none"
+    default_coupling = {"network_x": "diffusive", "network_y": "none"}
 
     def __init__(
         self, connectivity_matrix, delay_matrix, mass_params=None, seed=None,
@@ -162,6 +161,3 @@ class HopfNetwork(Network):
         assert all(all_couplings[0] == coupling for coupling in all_couplings)
         # invert as to name: idx
         self.coupling_symbols = {v: k for k, v in all_couplings[0].items()}
-
-    def _sync(self):
-        return self._couple(self.x_coupling, "x") + self._couple(self.y_coupling, "y") + super()._sync()

--- a/neurolib/models/multimodel/builder/hopf.py
+++ b/neurolib/models/multimodel/builder/hopf.py
@@ -79,7 +79,7 @@ class HopfMass(NeuralMass):
         return [d_x, d_y]
 
 
-class HopfNetworkNode(Node):
+class HopfNode(Node):
     """
     Default Hopf normal form node with 1 neural mass modelled as Landau-Stuart
     oscillator.
@@ -115,9 +115,12 @@ class HopfNetwork(Network):
     label = "HopfNet"
 
     sync_variables = ["network_x", "network_y"]
+    # define default coupling in Hopf network
+    x_coupling = "diffusive"
+    y_coupling = "none"
 
     def __init__(
-        self, connectivity_matrix, delay_matrix, mass_params=None, x_coupling="diffusive", y_coupling="none", seed=None,
+        self, connectivity_matrix, delay_matrix, mass_params=None, seed=None,
     ):
         """
         :param connectivity_matrix: connectivity matrix for between nodes
@@ -145,7 +148,7 @@ class HopfNetwork(Network):
 
         nodes = []
         for i, node_params in enumerate(mass_params):
-            node = HopfNetworkNode(params=node_params, seed=seeds[i])
+            node = HopfNode(params=node_params, seed=seeds[i])
             node.index = i
             node.idx_state_var = i * node.num_state_variables
             nodes.append(node)
@@ -159,9 +162,6 @@ class HopfNetwork(Network):
         assert all(all_couplings[0] == coupling for coupling in all_couplings)
         # invert as to name: idx
         self.coupling_symbols = {v: k for k, v in all_couplings[0].items()}
-
-        self.x_coupling = x_coupling
-        self.y_coupling = y_coupling
 
     def _sync(self):
         return self._couple(self.x_coupling, "x") + self._couple(self.y_coupling, "y") + super()._sync()

--- a/neurolib/models/multimodel/builder/thalamus.py
+++ b/neurolib/models/multimodel/builder/thalamus.py
@@ -124,7 +124,7 @@ class ThalamocorticalPopulation(ThalamicMass):
     num_state_variables = 10
     num_noise_variables = 1
     coupling_variables = {9: f"q_mean_{EXC}"}
-    required_couplings = ["node_exc_exc", "node_inh_exc", "network_exc_exc"]
+    required_couplings = ["node_exc_exc", "node_exc_inh", "network_exc_exc"]
     state_variable_names = [
         "V",
         "Ca",
@@ -267,7 +267,7 @@ class ThalamocorticalPopulation(ThalamicMass):
             - 2 * self.params["gamma_e"] * dsyn_ext
         )
         d_dsyn_inh = (
-            self.params["gamma_r"] ** 2 * (coupling_variables["node_inh_exc"] - syn_inh)
+            self.params["gamma_r"] ** 2 * (coupling_variables["node_exc_inh"] - syn_inh)
             - 2 * self.params["gamma_r"] * dsyn_inh
         )
         # firing rate as dummy dynamical variable with infinitely fast
@@ -302,7 +302,7 @@ class ThalamicReticularPopulation(ThalamicMass):
     num_state_variables = 7
     num_noise_variables = 1
     coupling_variables = {6: f"q_mean_{INH}"}
-    required_couplings = ["node_exc_inh", "node_inh_inh", "network_exc_inh"]
+    required_couplings = ["node_inh_exc", "node_inh_inh", "network_inh_exc"]
     state_variable_names = [
         "V",
         "h_T",
@@ -380,8 +380,8 @@ class ThalamicReticularPopulation(ThalamicMass):
         d_dsyn_ext = (
             self.params["gamma_e"] ** 2
             * (
-                coupling_variables["node_exc_inh"]
-                + coupling_variables["network_exc_inh"]
+                coupling_variables["node_inh_exc"]
+                + coupling_variables["network_inh_exc"]
                 + system_input(self.noise_input_idx[0])
                 - syn_ext
             )
@@ -416,7 +416,7 @@ class ThalamicNetworkNode(SingleCouplingExcitatoryInhibitoryNode):
     name = "Thalamic mass model node"
     label = "THLMnode"
 
-    default_network_coupling = {"network_exc_exc": 0.0, "network_exc_inh": 0.0}
+    default_network_coupling = {"network_exc_exc": 0.0, "network_inh_exc": 0.0}
     default_output = f"q_mean_{EXC}"
 
     def __init__(

--- a/neurolib/models/multimodel/builder/thalamus.py
+++ b/neurolib/models/multimodel/builder/thalamus.py
@@ -112,7 +112,7 @@ class ThalamicMass(NeuralMass):
         )
 
 
-class ThalamocorticalPopulation(ThalamicMass):
+class ThalamocorticalMass(ThalamicMass):
     """
     Excitatory mass representing thalamocortical relay neurons in the thalamus.
     """
@@ -289,7 +289,7 @@ class ThalamocorticalPopulation(ThalamicMass):
         ]
 
 
-class ThalamicReticularPopulation(ThalamicMass):
+class ThalamicReticularMass(ThalamicMass):
     """
     Inhibitory mass representing thalamic reticular nuclei neurons in the
     thalamus.
@@ -407,7 +407,7 @@ class ThalamicReticularPopulation(ThalamicMass):
         ]
 
 
-class ThalamicNetworkNode(SingleCouplingExcitatoryInhibitoryNode):
+class ThalamicNode(SingleCouplingExcitatoryInhibitoryNode):
     """
     Thalamic mass model network node with 1 excitatory (TCR) and 1 inhibitory
     (TRN) population due to Costa et al.
@@ -430,9 +430,9 @@ class ThalamicNetworkNode(SingleCouplingExcitatoryInhibitoryNode):
         :param connectivity: local connectivity matrix
         :type connectivity: np.ndarray
         """
-        tcr_mass = ThalamocorticalPopulation(params=tcr_params)
+        tcr_mass = ThalamocorticalMass(params=tcr_params)
         tcr_mass.index = 0
-        trn_mass = ThalamicReticularPopulation(params=trn_params)
+        trn_mass = ThalamicReticularMass(params=trn_params)
         trn_mass.index = 1
         super().__init__(
             neural_masses=[tcr_mass, trn_mass],

--- a/neurolib/models/multimodel/builder/thalamus.py
+++ b/neurolib/models/multimodel/builder/thalamus.py
@@ -1,0 +1,442 @@
+"""
+Thalamic mass models.
+
+References:
+    Costa, M. S., Weigenand, A., Ngo, H. V. V., Marshall, L., Born, J.,
+    Martinetz, T., & Claussen, J. C. (2016). A thalamocortical neural mass
+    model of the EEG during NREM sleep and its response to auditory stimulation.
+    PLoS computational biology, 12(9).
+"""
+
+import numpy as np
+from jitcdde import input as system_input
+from symengine import exp
+
+from ..builder.base.constants import EXC, INH, LAMBDA_SPEED
+from ..builder.base.network import SingleCouplingExcitatoryInhibitoryNode
+from ..builder.base.neural_mass import NeuralMass
+
+DEFAULT_PARAMS_TCR = {
+    "tau": 20.0,  # ms
+    "Q_max": 400.0e-3,  # 1/ms
+    "theta": -58.5,  # mV
+    "sigma": 6.0,
+    "C1": 1.8137993642,
+    "C_m": 1.0,  # muF/cm^2
+    "gamma_e": 70.0e-3,  # 1/ms
+    "gamma_r": 100.0e-3,  # 1/ms
+    "g_L": 1.0,  # AU
+    "g_GABA": 1.0,  # ms
+    "g_AMPA": 1.0,  # ms
+    "g_LK": 0.018,  # mS/cm^2
+    "g_T": 3.0,  # mS/cm^2
+    "g_h": 0.062,  # mS/cm^2
+    "E_AMPA": 0.0,  # mV
+    "E_GABA": -70.0,  # mV
+    "E_L": -70.0,  # mV
+    "E_K": -100.0,  # mV
+    "E_Ca": 120.0,  # mV
+    "E_h": -40.0,  # mV
+    "alpha_Ca": -51.8e-6,  # nmol
+    "tau_Ca": 10.0,  # ms
+    "Ca_0": 2.4e-4,
+    "k1": 2.5e7,
+    "k2": 4.0e-4,
+    "k3": 1.0e-1,
+    "k4": 1.0e-3,
+    "n_P": 4.0,
+    "g_inc": 2.0,
+    "ext_current": 0.0,
+    "lambda": LAMBDA_SPEED,
+}
+DEFAULT_PARAMS_TRN = {
+    "tau": 20.0,  # ms
+    "Q_max": 400.0e-3,  # 1/ms
+    "theta": -58.5,  # mV
+    "sigma": 6.0,
+    "C1": 1.8137993642,
+    "C_m": 1.0,  # muF/cm^2
+    "gamma_e": 70.0e-3,  # 1/ms
+    "gamma_r": 100.0e-3,  # 1/ms
+    "g_L": 1.0,  # AU
+    "g_GABA": 1.0,  # ms
+    "g_AMPA": 1.0,  # ms
+    "g_LK": 0.018,  # mS/cm^2
+    "g_T": 2.3,  # mS/cm^2
+    "E_AMPA": 0.0,  # mV
+    "E_GABA": -70.0,  # mV
+    "E_L": -70.0,  # mV
+    "E_K": -100.0,  # mV
+    "E_Ca": 120.0,  # mV
+    "ext_current": 0.0,
+    "lambda": LAMBDA_SPEED,
+}
+# matrix as [to, from], masses as (TCR, TRN)
+DEFAULT_THALAMIC_CONNECTIVITY = np.array([[0.0, 5.0], [3.0, 25.0]])
+
+
+class ThalamicMass(NeuralMass):
+    """
+    Base for thalamic neural populations due to Costa et al.
+    """
+
+    name = "Thalamic mass"
+    label = "THLM"
+
+    def _get_firing_rate(self, voltage):
+        return self.params["Q_max"] / (
+            1.0 + exp(-self.params["C1"] * (voltage - self.params["theta"]) / self.params["sigma"])
+        )
+
+    # synaptic currents
+    def _get_excitatory_current(self, voltage, synaptic_rate):
+        return self.params["g_AMPA"] * synaptic_rate * (voltage - self.params["E_AMPA"])
+
+    def _get_inhibitory_current(self, voltage, synaptic_rate):
+        return self.params["g_GABA"] * synaptic_rate * (voltage - self.params["E_GABA"])
+
+    # intrinsic currents
+    def _get_leak_current(self, voltage):
+        return self.params["g_L"] * (voltage - self.params["E_L"])
+
+    def _get_potassium_leak_current(self, voltage):
+        return self.params["g_LK"] * (voltage - self.params["E_K"])
+
+    def _get_T_type_current(self, voltage, h_T_value):
+        return (
+            self.params["g_T"]
+            * self._m_inf_T(voltage)
+            * self._m_inf_T(voltage)
+            * h_T_value
+            * (voltage - self.params["E_Ca"])
+        )
+
+
+class ThalamocorticalPopulation(ThalamicMass):
+    """
+    Excitatory mass representing thalamocortical relay neurons in the thalamus.
+    """
+
+    name = "Thalamocortical relay mass"
+    label = "TCR"
+    mass_type = EXC
+
+    num_state_variables = 10
+    num_noise_variables = 1
+    coupling_variables = {9: f"q_mean_{EXC}"}
+    required_couplings = ["node_exc_exc", "node_inh_exc", "network_exc_exc"]
+    state_variable_names = [
+        "V",
+        "Ca",
+        "h_T",
+        "m_h1",
+        "m_h2",
+        "s_e",
+        "s_i",
+        "ds_e",
+        "ds_i",
+        "q_mean",
+    ]
+    required_params = [
+        "tau",
+        "Q_max",
+        "theta",
+        "sigma",
+        "C1",
+        "C_m",
+        "gamma_e",
+        "gamma_r",
+        "g_L",
+        "g_GABA",
+        "g_AMPA",
+        "g_LK",
+        "g_T",
+        "g_h",
+        "E_AMPA",
+        "E_GABA",
+        "E_L",
+        "E_K",
+        "E_Ca",
+        "E_h",
+        "alpha_Ca",
+        "tau_Ca",
+        "Ca_0",
+        "k1",
+        "k2",
+        "k3",
+        "k4",
+        "n_P",
+        "g_inc",
+        "ext_current",
+        "lambda",
+    ]
+
+    def __init__(self, params=None):
+        super().__init__(params=params or DEFAULT_PARAMS_TCR)
+
+    def _initialize_state_vector(self):
+        """
+        Initialize state vector.
+        """
+        self.initial_state = [
+            self.params["E_L"],
+            self.params["Ca_0"],
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+        ]
+
+    def _get_anomalous_rectifier_current(self, voltage, m_h1_value, m_h2_value):
+        return self.params["g_h"] * (m_h1_value + self.params["g_inc"] * m_h2_value) * (voltage - self.params["E_h"])
+
+    def _m_inf_T(self, voltage):
+        return 1.0 / (1.0 + exp(-(voltage + 59.0) / 6.2))
+
+    def _h_inf_T(self, voltage):
+        return 1.0 / (1.0 + exp((voltage + 81.0) / 4.0))
+
+    def _tau_h_T(self, voltage):
+        return (30.8 + (211.4 + exp((voltage + 115.2) / 5.0)) / (1.0 + exp((voltage + 86.0) / 3.2))) / 3.7371928
+
+    def _m_inf_h(self, voltage):
+        return 1.0 / (1.0 + exp((voltage + 75.0) / 5.5))
+
+    def _tau_m_h(self, voltage):
+        return 20.0 + 1000.0 / (exp((voltage + 71.5) / 14.2) + exp(-(voltage + 89.0) / 11.6))
+
+    def _P_h(self, ca_conc):
+        return (self.params["k1"] * ca_conc ** self.params["n_P"]) / (
+            self.params["k1"] * ca_conc ** self.params["n_P"] + self.params["k2"]
+        )
+
+    def _derivatives(self, coupling_variables):
+        (
+            voltage,
+            ca_conc,
+            h_T,
+            m_h1,
+            m_h2,
+            syn_ext,
+            syn_inh,
+            dsyn_ext,
+            dsyn_inh,
+            firing_rate,
+        ) = self._unwrap_state_vector()
+        # voltage dynamics
+        d_voltage = -(
+            self._get_leak_current(voltage)
+            + self._get_excitatory_current(voltage, syn_ext)
+            + self._get_inhibitory_current(voltage, syn_inh)
+            + self.params["ext_current"]
+        ) / self.params["tau"] - (1.0 / self.params["C_m"]) * (
+            self._get_potassium_leak_current(voltage)
+            + self._get_T_type_current(voltage, h_T)
+            + self._get_anomalous_rectifier_current(voltage, m_h1, m_h2)
+        )
+        # calcium concetration dynamics
+        d_ca_conc = (
+            self.params["alpha_Ca"] * self._get_T_type_current(voltage, h_T)
+            - (ca_conc - self.params["Ca_0"]) / self.params["tau_Ca"]
+        )
+
+        # channel dynamics: T-type and rectifier current
+        d_h_T = (self._h_inf_T(voltage) - h_T) / self._tau_h_T(voltage)
+        d_m_h1 = (
+            (self._m_inf_h(voltage) * (1.0 - m_h2) - m_h1) / self._tau_m_h(voltage)
+            - self.params["k3"] * self._P_h(ca_conc) * m_h1
+            + self.params["k4"] * m_h2
+        )
+        d_m_h2 = self.params["k3"] * self._P_h(ca_conc) * m_h1 - self.params["k4"] * m_h2
+
+        # synaptic dynamics
+        d_syn_ext = dsyn_ext
+        d_syn_inh = dsyn_inh
+        d_dsyn_ext = (
+            self.params["gamma_e"] ** 2
+            * (
+                coupling_variables["node_exc_exc"]
+                + coupling_variables["network_exc_exc"]
+                + system_input(self.noise_input_idx[0])
+                - syn_ext
+            )
+            - 2 * self.params["gamma_e"] * dsyn_ext
+        )
+        d_dsyn_inh = (
+            self.params["gamma_r"] ** 2 * (coupling_variables["node_inh_exc"] - syn_inh)
+            - 2 * self.params["gamma_r"] * dsyn_inh
+        )
+        # firing rate as dummy dynamical variable with infinitely fast
+        # fixed-point dynamics
+        firing_rate_now = self._get_firing_rate(voltage)
+        d_firing_rate = -self.params["lambda"] * (firing_rate - firing_rate_now)
+
+        return [
+            d_voltage,
+            d_ca_conc,
+            d_h_T,
+            d_m_h1,
+            d_m_h2,
+            d_syn_ext,
+            d_syn_inh,
+            d_dsyn_ext,
+            d_dsyn_inh,
+            d_firing_rate,
+        ]
+
+
+class ThalamicReticularPopulation(ThalamicMass):
+    """
+    Inhibitory mass representing thalamic reticular nuclei neurons in the
+    thalamus.
+    """
+
+    name = "Thalamic reticular nuclei mass"
+    label = "TRN"
+    mass_type = INH
+
+    num_state_variables = 7
+    num_noise_variables = 1
+    coupling_variables = {6: f"q_mean_{INH}"}
+    required_couplings = ["node_exc_inh", "node_inh_inh", "network_exc_inh"]
+    state_variable_names = [
+        "V",
+        "h_T",
+        "s_e",
+        "s_i",
+        "ds_e",
+        "ds_i",
+        "q_mean",
+    ]
+    required_params = [
+        "tau",
+        "Q_max",
+        "theta",
+        "sigma",
+        "C1",
+        "C_m",
+        "gamma_e",
+        "gamma_r",
+        "g_L",
+        "g_GABA",
+        "g_AMPA",
+        "g_LK",
+        "g_T",
+        "E_AMPA",
+        "E_GABA",
+        "E_L",
+        "E_K",
+        "E_Ca",
+        "ext_current",
+        "lambda",
+    ]
+
+    def __init__(self, params=None):
+        super().__init__(params=params or DEFAULT_PARAMS_TRN)
+
+    def _m_inf_T(self, voltage):
+        return 1.0 / (1.0 + exp(-(voltage + 52.0) / 7.4))
+
+    def _h_inf_T(self, voltage):
+        return 1.0 / (1.0 + exp((voltage + 80.0) / 5.0))
+
+    def _tau_h_T(self, voltage):
+        return (85.0 + 1.0 / (exp((voltage + 48.0) / 4.0) + exp(-(voltage + 407.0) / 50.0))) / 3.7371928
+
+    def _initialize_state_vector(self):
+        """
+        Initialize state vector.
+        """
+        self.initial_state = [
+            self.params["E_L"],
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+        ]
+
+    def _derivatives(self, coupling_variables):
+        (voltage, h_T, syn_ext, syn_inh, dsyn_ext, dsyn_inh, firing_rate,) = self._unwrap_state_vector()
+        # voltage dynamics
+        d_voltage = -(
+            self._get_leak_current(voltage)
+            + self._get_excitatory_current(voltage, syn_ext)
+            + self._get_inhibitory_current(voltage, syn_inh)
+            + self.params["ext_current"]
+        ) / self.params["tau"] - (1.0 / self.params["C_m"]) * (
+            self._get_potassium_leak_current(voltage) + self._get_T_type_current(voltage, h_T)
+        )
+        # channel dynamics: T-type
+        d_h_T = (self._h_inf_T(voltage) - h_T) / self._tau_h_T(voltage)
+        # synaptic dynamics
+        d_syn_ext = dsyn_ext
+        d_syn_inh = dsyn_inh
+        d_dsyn_ext = (
+            self.params["gamma_e"] ** 2
+            * (
+                coupling_variables["node_exc_inh"]
+                + coupling_variables["network_exc_inh"]
+                + system_input(self.noise_input_idx[0])
+                - syn_ext
+            )
+            - 2 * self.params["gamma_e"] * dsyn_ext
+        )
+        d_dsyn_inh = (
+            self.params["gamma_r"] ** 2 * (coupling_variables["node_inh_inh"] - syn_inh)
+            - 2 * self.params["gamma_r"] * dsyn_inh
+        )
+        # firing rate as dummy dynamical variable with infinitely fast
+        # fixed-point dynamics
+        firing_rate_now = self._get_firing_rate(voltage)
+        d_firing_rate = -self.params["lambda"] * (firing_rate - firing_rate_now)
+
+        return [
+            d_voltage,
+            d_h_T,
+            d_syn_ext,
+            d_syn_inh,
+            d_dsyn_ext,
+            d_dsyn_inh,
+            d_firing_rate,
+        ]
+
+
+class ThalamicNetworkNode(SingleCouplingExcitatoryInhibitoryNode):
+    """
+    Thalamic mass model network node with 1 excitatory (TCR) and 1 inhibitory
+    (TRN) population due to Costa et al.
+    """
+
+    name = "Thalamic mass model node"
+    label = "THLMnode"
+
+    default_network_coupling = {"network_exc_exc": 0.0, "network_exc_inh": 0.0}
+    default_output = f"q_mean_{EXC}"
+
+    def __init__(
+        self, tcr_params=None, trn_params=None, connectivity=DEFAULT_THALAMIC_CONNECTIVITY,
+    ):
+        """
+        :param tcr_params: parameters for the excitatory (TCR) mass
+        :type tcr_params: dict|None
+        :param trn_params: parameters for the inhibitory (TRN) mass
+        :type trn_params: dict|None
+        :param connectivity: local connectivity matrix
+        :type connectivity: np.ndarray
+        """
+        tcr_mass = ThalamocorticalPopulation(params=tcr_params)
+        tcr_mass.index = 0
+        trn_mass = ThalamicReticularPopulation(params=trn_params)
+        trn_mass.index = 1
+        super().__init__(
+            neural_masses=[tcr_mass, trn_mass],
+            local_connectivity=connectivity,
+            # within thalamic node there are no local delays
+            local_delays=None,
+        )

--- a/neurolib/models/multimodel/builder/wilson_cowan.py
+++ b/neurolib/models/multimodel/builder/wilson_cowan.py
@@ -164,6 +164,8 @@ class WilsonCowanNetwork(Network):
     label = "WCnet"
 
     sync_variables = ["network_exc_exc", "network_inh_exc"]
+    # define default coupling in Wilson-Cowan network
+    default_coupling = {"network_exc_exc": "additive", "network_inh_exc": "additive"}
 
     def __init__(
         self,
@@ -229,12 +231,4 @@ class WilsonCowanNetwork(Network):
         )
         # assert we have two sync variables
         assert len(self.sync_variables) == 2
-
-    def _sync(self):
-        # excitatory population within the node is first, hence the
-        # within_node_idx is 0
-        return (
-            self._additive_coupling(within_node_idx=0, symbol="network_exc_exc")
-            + self._additive_coupling(within_node_idx=0, symbol="network_inh_exc")
-            + super()._sync()
-        )
+        self.coupling_symbols = {"exc_exc": 0, "inh_exc": 0}

--- a/neurolib/models/multimodel/builder/wilson_cowan.py
+++ b/neurolib/models/multimodel/builder/wilson_cowan.py
@@ -1,0 +1,209 @@
+"""
+Wilson-Cowan model.
+
+Main reference:
+    Wilson, H. R., & Cowan, J. D. (1972). Excitatory and inhibitory
+    interactions in localized populations of model neurons. Biophysical journal,
+    12(1), 1-24.
+
+Additional reference:
+    Papadopoulos, L., Lynn, C. W., Battaglia, D., & Bassett, D. S. (2020).
+    Relations between large scale brain connectivity and effects of regional
+    stimulation depend on collective dynamical state. arXiv preprint
+    arXiv:2002.00094.
+"""
+
+import numpy as np
+from jitcdde import input as system_input
+from symengine import exp
+
+from ..builder.base.constants import EXC, INH
+from ..builder.base.network import Network, SingleCouplingExcitatoryInhibitoryNode
+from ..builder.base.neural_mass import NeuralMass
+
+DEFAULT_PARAMS_EXC = {"a": 1.5, "mu": 3.0, "tau": 2.5, "ext_input": 0.6}
+DEFAULT_PARAMS_INH = {"a": 1.5, "mu": 3.0, "tau": 3.75, "ext_input": 0.0}
+# matrix as [to, from], masses as (EXC, INH)
+DEFAULT_WC_NODE_CONNECTIVITY = np.array([[16.0, 12.0], [15.0, 3.0]])
+
+
+class WilsonCowanMass(NeuralMass):
+    """
+    Wilson-Cowan neural mass. Can be excitatory or inhibitory, depending on the
+    parameters.
+    """
+
+    name = "Wilson-Cowan mass"
+    label = "WCmass"
+
+    num_state_variables = 1
+    num_noise_variables = 1
+    coupling_variables = {0: "q_mean"}
+    state_variable_names = ["q_mean"]
+    required_params = ["a", "mu", "tau", "ext_input"]
+
+    def _initialize_state_vector(self):
+        """
+        Initialize state vector.
+        """
+        self.initial_state = [0.05 * np.random.uniform(0, 1)]
+
+    def _sigmoid(self, x):
+        return 1.0 / (1.0 + exp(-self.params["a"] * (x - self.params["mu"])))
+
+
+class ExcitatoryWilsonCowanMass(WilsonCowanMass):
+    """
+    Excitatory Wilson-Cowan neural mass.
+    """
+
+    name = "Wilson-Cowan excitatory mass"
+    label = f"WCmass{EXC}"
+    coupling_variables = {0: f"q_mean_{EXC}"}
+    state_variable_names = [f"q_mean_{EXC}"]
+    mass_type = EXC
+    required_couplings = ["node_exc_exc", "node_inh_exc", "network_exc_exc"]
+
+    def __init__(self, params=None):
+        super().__init__(params=params or DEFAULT_PARAMS_EXC)
+
+    def _derivatives(self, coupling_variables):
+        [x] = self._unwrap_state_vector()
+        d_x = (
+            -x
+            + (1.0 - x)
+            * self._sigmoid(
+                coupling_variables["node_exc_exc"]
+                - coupling_variables["node_inh_exc"]
+                + coupling_variables["network_exc_exc"]
+                + self.params["ext_input"]
+            )
+            + system_input(self.noise_input_idx[0])
+        ) / self.params["tau"]
+
+        return [d_x]
+
+
+class InhibitoryWilsonCowanMass(WilsonCowanMass):
+
+    name = "Wilson-Cowan inhibitory mass"
+    label = f"WCmass{INH}"
+    coupling_variables = {0: f"q_mean_{INH}"}
+    state_variable_names = [f"q_mean_{INH}"]
+    mass_type = INH
+    required_couplings = ["node_exc_inh", "node_inh_inh"]
+
+    def __init__(self, params=None):
+        super().__init__(params=params or DEFAULT_PARAMS_INH)
+
+    def _derivatives(self, coupling_variables):
+        [x] = self._unwrap_state_vector()
+        d_x = (
+            -x
+            + (1.0 - x)
+            * self._sigmoid(
+                coupling_variables["node_exc_inh"] - coupling_variables["node_inh_inh"] + self.params["ext_input"]
+            )
+            + system_input(self.noise_input_idx[0])
+        ) / self.params["tau"]
+
+        return [d_x]
+
+
+class WilsonCowanNetworkNode(SingleCouplingExcitatoryInhibitoryNode):
+    """
+    Default Wilson-Cowan network node with 1 excitatory and 1 inhibitory
+    population.
+    """
+
+    name = "Wilson-Cowan node"
+    label = "WCnode"
+
+    default_output = f"q_mean_{EXC}"
+
+    def __init__(
+        self, exc_params=None, inh_params=None, connectivity=DEFAULT_WC_NODE_CONNECTIVITY,
+    ):
+        """
+        :param exc_params: parameters for the excitatory mass
+        :type exc_params: dict|None
+        :param inh_params: parameters for the inhibitory mass
+        :type inh_params: dict|None
+        :param connectivity: local connectivity matrix
+        :type connectivity: np.ndarray
+        """
+        excitatory_mass = ExcitatoryWilsonCowanMass(exc_params)
+        excitatory_mass.index = 0
+        inhibitory_mass = InhibitoryWilsonCowanMass(inh_params)
+        inhibitory_mass.index = 1
+        super().__init__(
+            neural_masses=[excitatory_mass, inhibitory_mass],
+            local_connectivity=connectivity,
+            # within W-C node there are no local delays
+            local_delays=None,
+        )
+
+
+class WilsonCowanNetwork(Network):
+    """
+    Whole brain network of Wilson-Cowan excitatory and inhibitory nodes.
+    """
+
+    name = "Wilson-Cowan network"
+    label = "WCnet"
+
+    sync_variables = ["network_exc_exc"]
+
+    def __init__(
+        self,
+        connectivity_matrix,
+        delay_matrix,
+        exc_mass_params=None,
+        inh_mass_params=None,
+        local_connectivity=DEFAULT_WC_NODE_CONNECTIVITY,
+    ):
+        """
+        :param connectivity_matrix: connectivity matrix for between nodes
+            coupling, typically DTI structural connectivity, matrix as [from,
+            to]
+        :type connectivity_matrix: np.ndarray
+        :param delay_matrix: delay matrix between nodes, typically derived from
+            length matrix, if None, delays are all zeros, in ms, matrix as
+            [from, to]
+        :type delay_matrix: np.ndarray|None
+        :param exc_mass_params: parameters for each excitatory Wilson-Cowan
+            neural mass, if None, will use default
+        :type exc_mass_params: list[dict]|dict|None
+        :param inh_mass_params: parameters for each inhibitory Wilson-Cowan
+            neural mass, if None, will use default
+        :type inh_mass_params: list[dict]|dict|None
+        :param local_connectivity: local within-node connectivity matrix
+        :type local_connectivity: list[np.ndarray]|np.ndarray
+        """
+        num_nodes = connectivity_matrix.shape[0]
+        exc_mass_params = self._prepare_mass_params(exc_mass_params, num_nodes)
+        inh_mass_params = self._prepare_mass_params(inh_mass_params, num_nodes)
+        local_connectivity = self._prepare_mass_params(local_connectivity, num_nodes, native_type=np.ndarray)
+
+        nodes = []
+        for i, (exc_params, inh_params, local_conn) in enumerate(
+            zip(exc_mass_params, inh_mass_params, local_connectivity)
+        ):
+            node = WilsonCowanNetworkNode(exc_params=exc_params, inh_params=inh_params, connectivity=local_conn,)
+            node.index = i
+            node.idx_state_var = i * node.num_state_variables
+            # set correct indices of noise input
+            for mass in node:
+                mass.noise_input_idx = [2 * i + mass.index]
+            nodes.append(node)
+
+        super().__init__(
+            nodes=nodes, connectivity_matrix=connectivity_matrix, delay_matrix=delay_matrix,
+        )
+        # assert we have only one sync variable
+        assert len(self.sync_variables) == 1
+
+    def _sync(self):
+        # excitatory population within the node is first, hence the
+        # within_node_idx is 0
+        return self._additive_coupling(within_node_idx=0, symbol=self.sync_variables[0]) + super()._sync()

--- a/neurolib/models/multimodel/builder/wilson_cowan.py
+++ b/neurolib/models/multimodel/builder/wilson_cowan.py
@@ -114,7 +114,7 @@ class InhibitoryWilsonCowanMass(WilsonCowanMass):
         return [d_x]
 
 
-class WilsonCowanNetworkNode(SingleCouplingExcitatoryInhibitoryNode):
+class WilsonCowanNode(SingleCouplingExcitatoryInhibitoryNode):
     """
     Default Wilson-Cowan network node with 1 excitatory and 1 inhibitory
     population.
@@ -210,7 +210,7 @@ class WilsonCowanNetwork(Network):
         for i, (exc_params, inh_params, local_conn) in enumerate(
             zip(exc_mass_params, inh_mass_params, local_connectivity)
         ):
-            node = WilsonCowanNetworkNode(
+            node = WilsonCowanNode(
                 exc_params=exc_params,
                 inh_params=inh_params,
                 connectivity=local_conn,

--- a/neurolib/models/multimodel/builder/wilson_cowan.py
+++ b/neurolib/models/multimodel/builder/wilson_cowan.py
@@ -177,12 +177,12 @@ class WilsonCowanNetwork(Network):
     ):
         """
         :param connectivity_matrix: connectivity matrix for between nodes
-            coupling, typically DTI structural connectivity, matrix as [from,
-            to]
+            coupling, typically DTI structural connectivity, matrix as [to,
+            from]
         :type connectivity_matrix: np.ndarray
         :param delay_matrix: delay matrix between nodes, typically derived from
             length matrix, if None, delays are all zeros, in ms, matrix as
-            [from, to]
+            [to, from]
         :type delay_matrix: np.ndarray|None
         :param exc_mass_params: parameters for each excitatory Wilson-Cowan
             neural mass, if None, will use default

--- a/neurolib/models/multimodel/builder/wong_wang.py
+++ b/neurolib/models/multimodel/builder/wong_wang.py
@@ -268,6 +268,7 @@ class ReducedWongWangNetworkNode(Node):
     label = "ReducedWWnode"
 
     default_network_coupling = {"network_s": 0.0}
+    default_output = "S"
 
     def __init__(self, params=None):
         """
@@ -280,3 +281,6 @@ class ReducedWongWangNetworkNode(Node):
 
     def _sync(self):
         return []
+
+
+# TODO add network instances for both WW versions, after checking with TVB

--- a/neurolib/models/multimodel/builder/wong_wang.py
+++ b/neurolib/models/multimodel/builder/wong_wang.py
@@ -305,6 +305,8 @@ class WongWangNetwork(Network):
     label = "WWnet"
 
     sync_variables = ["network_exc_exc", "network_inh_exc"]
+    # define default coupling in Wong-Wang network
+    default_coupling = {"network_exc_exc": "additive", "network_inh_exc": "additive"}
 
     def __init__(
         self,
@@ -370,15 +372,7 @@ class WongWangNetwork(Network):
         )
         # assert we have two sync variables
         assert len(self.sync_variables) == 2
-
-    def _sync(self):
-        # excitatory population within the node is first, hence the
-        # within_node_idx is 0
-        return (
-            self._additive_coupling(within_node_idx=0, symbol="network_exc_exc")
-            + self._additive_coupling(within_node_idx=0, symbol="network_inh_exc")
-            + super()._sync()
-        )
+        self.coupling_symbols = {"exc_exc": 0, "inh_exc": 0}
 
 
 class ReducedWongWangNetwork(Network):
@@ -391,7 +385,7 @@ class ReducedWongWangNetwork(Network):
 
     sync_variables = ["network_S"]
     # define default coupling in Reduced Wong-Wang network
-    s_coupling = "additive"
+    default_coupling = {"network_S": "additive"}
 
     def __init__(self, connectivity_matrix, delay_matrix, mass_params=None, seed=None):
         """
@@ -428,6 +422,3 @@ class ReducedWongWangNetwork(Network):
         assert all(all_couplings[0] == coupling for coupling in all_couplings)
         # invert as to name: idx
         self.coupling_symbols = {v: k for k, v in all_couplings[0].items()}
-
-    def _sync(self):
-        return self._couple(self.s_coupling, "S") + super()._sync()

--- a/neurolib/models/multimodel/builder/wong_wang.py
+++ b/neurolib/models/multimodel/builder/wong_wang.py
@@ -1,0 +1,282 @@
+"""
+Wong-Wang model. Contains both:
+    - classical Wong-Wang with one network node containing one excitatory and
+        one inhibitory mass
+    - Reduced Wong-Wang model with one mass per node
+
+Main reference:
+    [original] Wong, K. F., & Wang, X. J. (2006). A recurrent network mechanism
+    of time integration in perceptual decisions. Journal of Neuroscience, 26(4),
+    1314-1328.
+
+Additional references:
+    [reduced] Deco, G., Ponce-Alvarez, A., Mantini, D., Romani, G. L., Hagmann,
+    P., & Corbetta, M. (2013). Resting-state functional connectivity emerges
+    from structurally and dynamically shaped slow linear fluctuations. Journal
+    of Neuroscience, 33(27), 11239-11252.
+
+    [original] Deco, G., Ponce-Alvarez, A., Hagmann, P., Romani, G. L., Mantini,
+    D., & Corbetta, M. (2014). How local excitation–inhibition ratio impacts the
+    whole brain dynamics. Journal of Neuroscience, 34(23), 7886-7898.
+"""
+
+import numpy as np
+from jitcdde import input as system_input
+from symengine import exp
+
+from ..builder.base.constants import EXC, INH, LAMBDA_SPEED
+from ..builder.base.network import Node, SingleCouplingExcitatoryInhibitoryNode
+from ..builder.base.neural_mass import NeuralMass
+
+# TODO compare with TVB (at least the reduced version - they have it)
+
+DEFAULT_PARAMS_EXC = {
+    "a": 310.0,  # nC^-1
+    "b": 0.125,  # kHz
+    "d": 160.0,  # ms
+    "tau": 100.0,  # ms
+    "gamma": 0.641,
+    "W": 1.0,
+    "exc_current": 0.382,  # nA
+    "J": 0.15,  # nA
+    "lambda": LAMBDA_SPEED,
+}
+DEFAULT_PARAMS_INH = {
+    "a": 615.0,  # nC^-1
+    "b": 0.177,  # kHz
+    "d": 87.0,  # ms
+    "tau": 10.0,  # ms
+    "W": 0.7,
+    "exc_current": 0.382,  # nA
+    "lambda": LAMBDA_SPEED,
+}
+DEFAULT_PARAMS_REDUCED = {
+    "a": 270.0,  # nC^-1
+    "b": 0.108,  # kHz
+    "d": 154.0,  # ms
+    "tau": 100.0,  # ms
+    "gamma": 0.641 / 1000.0,
+    "w": 0.6,
+    "J": 0.2609,  # nA
+    "exc_current": 0.3,  # nA
+    "lambda": LAMBDA_SPEED,
+}
+
+# matrix as [to, from], masses as (EXC, INH)
+DEFAULT_WW_NODE_CONNECTIVITY = np.array([[1.4, 1.0], [1.0, 1.0]])
+
+
+class WongWangMass(NeuralMass):
+    """
+    Wong-Wang neural mass. Can be excitatory or inhibitory, depending on the
+    parameters. Also a base for reduced Wong-Wang mass.
+    """
+
+    name = "Wong-Wang mass"
+    label = "WWmass"
+
+    num_state_variables = 2
+    num_noise_variables = 1
+    coupling_variables = {0: "S"}
+    state_variable_names = ["S", "q_mean"]
+
+    def _initialize_state_vector(self):
+        """
+        Initialize state vector.
+        """
+        self.initial_state = (np.random.uniform(0, 1) * np.array([1.0, 0.01])).tolist()
+
+    def _get_firing_rate(self, current):
+        return (self.params["a"] * current - self.params["b"]) / (
+            1.0 - exp(-self.params["d"] * (self.params["a"] * current - self.params["b"]))
+        )
+
+
+class ExcitatoryWongWangMass(WongWangMass):
+    """
+    Excitatory Wong-Wang neural mass.
+    """
+
+    name = "Wong-Wang excitatory mass"
+    label = f"WWmass{EXC}"
+    mass_type = EXC
+    coupling_variables = {0: f"S_{EXC}"}
+    state_variable_names = [f"S_{EXC}", f"q_mean_{EXC}"]
+    required_couplings = ["node_exc_exc", "node_inh_exc", "network_exc_exc"]
+    required_params = [
+        "a",
+        "b",
+        "d",
+        "tau",
+        "gamma",
+        "W",
+        "exc_current",
+        "J",
+        "lambda",
+    ]
+
+    def __init__(self, params=None):
+        super().__init__(params=params or DEFAULT_PARAMS_EXC)
+
+    def _derivatives(self, coupling_variables):
+        [s, firing_rate] = self._unwrap_state_vector()
+
+        current = (
+            self.params["W"] * self.params["exc_current"]
+            + coupling_variables["node_exc_exc"]
+            + self.params["J"] * coupling_variables["network_exc_exc"]
+            - coupling_variables["node_inh_exc"]
+        )
+        firing_rate_now = self._get_firing_rate(current)
+        d_s = (
+            (-s / self.params["tau"])
+            + (1.0 - s) * self.params["gamma"] * firing_rate_now
+            + system_input(self.noise_input_idx[0])
+        )
+        # firing rate as dummy dynamical variable with infinitely fast
+        # fixed-point dynamics
+        d_firing_rate = -self.params["lambda"] * (firing_rate - firing_rate_now)
+
+        return [d_s, d_firing_rate]
+
+
+class InhibitoryWongWangMass(WongWangMass):
+    """
+    Inhibitory Wong-Wang neural mass.
+    """
+
+    name = "Wong-Wang inhibitory mass"
+    label = f"WWmass{INH}"
+    mass_type = INH
+    coupling_variables = {0: f"S_{INH}"}
+    state_variable_names = [f"S_{INH}", f"q_mean_{INH}"]
+    required_couplings = ["node_exc_inh", "node_inh_inh"]
+    required_params = [
+        "a",
+        "b",
+        "d",
+        "tau",
+        "W",
+        "exc_current",
+        "lambda",
+    ]
+
+    def __init__(self, params=None):
+        super().__init__(params=params or DEFAULT_PARAMS_INH)
+
+    def _derivatives(self, coupling_variables):
+        [s, firing_rate] = self._unwrap_state_vector()
+
+        current = (
+            self.params["W"] * self.params["exc_current"]
+            + coupling_variables["node_exc_inh"]
+            - coupling_variables["node_inh_inh"]
+        )
+        firing_rate_now = self._get_firing_rate(current)
+        d_s = (-s / self.params["tau"]) + firing_rate_now + system_input(self.noise_input_idx[0])
+        # firing rate as dummy dynamical variable with infinitely fast
+        # fixed-point dynamics
+        d_firing_rate = -self.params["lambda"] * (firing_rate - firing_rate_now)
+
+        return [d_s, d_firing_rate]
+
+
+class ReducedWongWangMass(WongWangMass):
+    """
+    Reduced Wong-Wang neural mass - only NMDA gating variable, which dominates
+    the evolution of the system.
+    """
+
+    name = "Reduced Wong-Wang mass"
+    label = "ReducedWWmass"
+    required_couplings = ["network_s"]
+    required_params = [
+        "a",
+        "b",
+        "d",
+        "tau",
+        "gamma",
+        "w",
+        "J",
+        "exc_current",
+        "lambda",
+    ]
+
+    def __init__(self, params=None):
+        super().__init__(params=params or DEFAULT_PARAMS_REDUCED)
+
+    def _derivatives(self, coupling_variables):
+        [s, firing_rate] = self._unwrap_state_vector()
+
+        current = (
+            self.params["w"] * self.params["J"] * s
+            + self.params["J"] * coupling_variables["network_s"]
+            + self.params["exc_current"]
+        )
+        firing_rate_now = self._get_firing_rate(current)
+        d_s = (
+            (-s / self.params["tau"])
+            + (1.0 - s) * self.params["gamma"] * firing_rate_now
+            + system_input(self.noise_input_idx[0])
+        )
+        # firing rate as dummy dynamical variable with infinitely fast
+        # fixed-point dynamics
+        d_firing_rate = -self.params["lambda"] * (firing_rate - firing_rate_now)
+
+        return [d_s, d_firing_rate]
+
+
+class WongWangNetworkNode(SingleCouplingExcitatoryInhibitoryNode):
+    """
+    Default Wong-Wang network node with 1 excitatory and 1 inhibitory popultion.
+    """
+
+    name = "Wong-Wang node"
+    label = "WWnode"
+
+    default_output = f"S_{EXC}"
+
+    def __init__(
+        self, exc_params=None, inh_params=None, connectivity=DEFAULT_WW_NODE_CONNECTIVITY,
+    ):
+        """
+        :param exc_params: parameters for the excitatory mass
+        :type exc_params: dict|None
+        :param inh_params: parameters for the inhibitory mass
+        :type inh_params: dict|None
+        :param connectivity: local connectivity matrix
+        :type connectivity: np.ndarray
+        """
+        excitatory_mass = ExcitatoryWongWangMass(exc_params)
+        excitatory_mass.index = 0
+        inhibitory_mass = InhibitoryWongWangMass(inh_params)
+        inhibitory_mass.index = 1
+        super().__init__(
+            neural_masses=[excitatory_mass, inhibitory_mass],
+            local_connectivity=connectivity,
+            # within W-W node there are no local delays
+            local_delays=None,
+        )
+
+
+class ReducedWongWangNetworkNode(Node):
+    """
+    Default reduced Wong-Wang network node with 1 neural mass.
+    """
+
+    name = "Reduced Wong-Wang node"
+    label = "ReducedWWnode"
+
+    default_network_coupling = {"network_s": 0.0}
+
+    def __init__(self, params=None):
+        """
+        :param params: parameters of the reduced Wong-Wang mass
+        :type params: dict|None
+        """
+        reduced_ww_mass = ReducedWongWangMass(params)
+        reduced_ww_mass.index = 0
+        super().__init__(neural_masses=[reduced_ww_mass])
+
+    def _sync(self):
+        return []

--- a/neurolib/models/multimodel/builder/wong_wang.py
+++ b/neurolib/models/multimodel/builder/wong_wang.py
@@ -51,14 +51,14 @@ DEFAULT_PARAMS_INH = {
     "lambda": LAMBDA_SPEED,
 }
 DEFAULT_PARAMS_REDUCED = {
-    "a": 270.0,  # nC^-1
+    "a": 0.27,  # nC^-1
     "b": 0.108,  # kHz
     "d": 154.0,  # ms
     "tau": 100.0,  # ms
-    "gamma": 0.641 / 1000.0,
+    "gamma": 0.641,  # kinetic parameter
     "w": 0.6,
     "J": 0.2609,  # nA
-    "exc_current": 0.3,  # nA
+    "exc_current": 0.33,  # nA
     "lambda": LAMBDA_SPEED,
 }
 

--- a/neurolib/models/wc/timeIntegration.py
+++ b/neurolib/models/wc/timeIntegration.py
@@ -232,7 +232,7 @@ def timeIntegration_njit_elementwise(
                     * S_I(
                         c_excinh * excs[no, i - 1]  # input from the excitatory population
                         - c_inhinh * inhs[no, i - 1]  # input from within the inhibitory population
-                        + exc_input_d[no]  # input from other nodes
+                        + inh_input_d[no]  # input from other nodes
                         + inh_ext[no]
                     )  # external input
                     + inh_ou[no]  # ou noise

--- a/neurolib/models/wc/timeIntegration.py
+++ b/neurolib/models/wc/timeIntegration.py
@@ -232,7 +232,7 @@ def timeIntegration_njit_elementwise(
                     * S_I(
                         c_excinh * excs[no, i - 1]  # input from the excitatory population
                         - c_inhinh * inhs[no, i - 1]  # input from within the inhibitory population
-                        + inh_input_d[no]  # input from other nodes
+                        + exc_input_d[no]  # input from other nodes
                         + inh_ext[no]
                     )  # external input
                     + inh_ou[no]  # ou noise

--- a/neurolib/optimize/evolution/evolution.py
+++ b/neurolib/optimize/evolution/evolution.py
@@ -772,9 +772,9 @@ class Evolution:
                             df.at[i, key] = value
                         elif isinstance(value, (float, int)):
                             # save numbers
-                            df.loc[runId, key] = value
+                            df.loc[i, key] = value
                     else:
-                        df.loc[runId, key] = nan_value
+                        df.loc[i, key] = nan_value
         return df
 
     def _dropDuplicatesFromDf(self, df):

--- a/tests/multimodel/base/test_backend.py
+++ b/tests/multimodel/base/test_backend.py
@@ -6,7 +6,7 @@ import os
 import pickle
 import unittest
 from shutil import rmtree
-
+import numba
 import numpy as np
 import pytest
 import symengine as se
@@ -32,6 +32,11 @@ class TestBaseBackend(unittest.TestCase):
         self.assertEqual(base.max_delay, None)
         self.assertEqual(base.state_variable_names, None)
         self.assertEqual(base.label, None)
+
+    def test_methods(self):
+        base = BaseBackend()
+        base.clean()
+        self.assertRaises(NotImplementedError, base.run)
 
 
 class TestJitcddeBackend(unittest.TestCase):
@@ -177,6 +182,21 @@ class TestBackendIntegrator(unittest.TestCase):
         )
         self.assertTrue(all(dim in results.dims for dim in ["time", "node"]))
         self.assertDictEqual(results.attrs, self.EXTRA_ATTRS)
+
+    def test_jitcdde_other_features(self):
+        system = BackendTestingHelper()
+        _ = system.run(self.DURATION, self.DT, ZeroInput(self.DURATION, self.DT).as_cubic_splines(), backend="jitcdde")
+        system.backend_instance._check()
+        system.backend_instance.dde_system.reset_integrator()
+        system.backend_instance._integrate_blindly(system.max_delay)
+        system.clean()
+
+    def test_backend_value_error(self):
+        system = BackendTestingHelper()
+        with pytest.raises(ValueError):
+            _ = system.run(
+                self.DURATION, self.DT, ZeroInput(self.DURATION, self.DT).as_cubic_splines(), backend="wrong"
+            )
 
     def test_return_raw_and_xarray(self):
         system = BackendTestingHelper()

--- a/tests/multimodel/base/test_backend.py
+++ b/tests/multimodel/base/test_backend.py
@@ -6,7 +6,7 @@ import os
 import pickle
 import unittest
 from shutil import rmtree
-import numba
+
 import numpy as np
 import pytest
 import symengine as se

--- a/tests/multimodel/base/test_network.py
+++ b/tests/multimodel/base/test_network.py
@@ -68,6 +68,10 @@ class TestNode(unittest.TestCase):
         self.assertTrue(isinstance(node.default_network_coupling, dict))
         self.assertTrue(isinstance(node.sync_variables, list))
 
+    def test_sync(self):
+        node = self._create_node()
+        self.assertRaises(NotImplementedError, node._sync)
+
     def test_update_params(self):
         UPDATE_WITH = {"a": 2.4}
 
@@ -125,11 +129,20 @@ class TestSingleCouplingExcitatoryInhibitoryNode(unittest.TestCase):
     def test_update_params(self):
         UPDATE_WITH = {"a": 2.4}
         UPDATE_CONNECTIVITY = np.random.rand(2, 2)
+        UPDATE_DELAYS = np.abs(np.random.rand(2, 2))
         node = self._create_node()
-        node.update_params({"mass_0": UPDATE_WITH, "mass_1": UPDATE_WITH, "local_connectivity": UPDATE_CONNECTIVITY})
+        node.update_params(
+            {
+                "mass_0": UPDATE_WITH,
+                "mass_1": UPDATE_WITH,
+                "local_connectivity": UPDATE_CONNECTIVITY,
+                "local_delays": UPDATE_DELAYS,
+            }
+        )
         self.assertDictEqual({**PARAMS, **UPDATE_WITH}, node[0].params)
         self.assertDictEqual({**PARAMS, **UPDATE_WITH}, node[1].params)
         np.testing.assert_equal(UPDATE_CONNECTIVITY, node.connectivity)
+        np.testing.assert_equal(UPDATE_DELAYS, node.delays)
 
     def test_init_node(self):
         node = self._create_node()
@@ -187,10 +200,14 @@ class TestNetwork(unittest.TestCase):
     def test_update_params(self):
         UPDATE_CONNECTIVITY = np.random.rand(2, 2)
         UPDATE_DELAYS = np.abs(np.random.rand(2, 2))
+        UPDATE_WITH = {"a": 2.4}
         net, _ = self._create_network()
-        net.update_params({"connectivity": UPDATE_CONNECTIVITY, "delays": UPDATE_DELAYS})
+        net.update_params(
+            {"connectivity": UPDATE_CONNECTIVITY, "delays": UPDATE_DELAYS, "node_0": {"mass_0": UPDATE_WITH}}
+        )
         np.testing.assert_equal(net.connectivity, UPDATE_CONNECTIVITY)
         np.testing.assert_equal(net.delays, UPDATE_DELAYS)
+        self.assertEqual(net[0][0].params["a"], UPDATE_WITH["a"])
 
     def test_prepare_mass_params(self):
         net, _ = self._create_network()

--- a/tests/multimodel/base/test_neural_mass.py
+++ b/tests/multimodel/base/test_neural_mass.py
@@ -37,6 +37,10 @@ class TestNeuralMass(unittest.TestCase):
         # callbacks are UndefFunction for now
         self.assertTrue(all(isinstance(callback, se.UndefFunction) for callback in mass.callback_functions.values()))
 
+    def test_derivatives(self):
+        mass = MassTest(self.PARAMS)
+        self.assertRaises(NotImplementedError, mass._derivatives)
+
     def test_validate_params(self):
         mass = MassTest(self.PARAMS)
         self.assertDictEqual(self.PARAMS, mass.params)

--- a/tests/multimodel/test_fitzhugh_nagumo.py
+++ b/tests/multimodel/test_fitzhugh_nagumo.py
@@ -12,7 +12,7 @@ from neurolib.models.multimodel.builder.fitzhugh_nagumo import (
     DEFAULT_PARAMS,
     FitzHughNagumoMass,
     FitzHughNagumoNetwork,
-    FitzHughNagumoNetworkNode,
+    FitzHughNagumoNode,
 )
 from neurolib.models.multimodel.builder.model_input import ZeroInput
 
@@ -64,9 +64,9 @@ class TestFitzHughNagumoMass(MassTestCase):
         self.assertTupleEqual(result.shape, (int(DURATION / DT), fhn.num_state_variables))
 
 
-class TestFitzHughNagumoNetworkNode(unittest.TestCase):
+class TestFitzHughNagumoNode(unittest.TestCase):
     def _create_node(self):
-        node = FitzHughNagumoNetworkNode(seed=SEED)
+        node = FitzHughNagumoNode(seed=SEED)
         node.index = 0
         node.idx_state_var = 0
         node.init_node()
@@ -74,7 +74,7 @@ class TestFitzHughNagumoNetworkNode(unittest.TestCase):
 
     def test_init(self):
         fhn = self._create_node()
-        self.assertTrue(isinstance(fhn, FitzHughNagumoNetworkNode))
+        self.assertTrue(isinstance(fhn, FitzHughNagumoNode))
         self.assertEqual(len(fhn), 1)
         self.assertDictEqual(fhn[0].params, DEFAULT_PARAMS)
         self.assertEqual(len(fhn.default_network_coupling), 2)

--- a/tests/multimodel/test_fitzhugh_nagumo.py
+++ b/tests/multimodel/test_fitzhugh_nagumo.py
@@ -1,7 +1,7 @@
 """
 Set of tests for FitzHugh-Nagumo model.
 """
-
+import numba
 import unittest
 
 import numpy as np
@@ -48,7 +48,7 @@ class TestFitzHughNagumoMass(MassTestCase):
     def test_init(self):
         fhn = self._create_mass()
         self.assertTrue(isinstance(fhn, FitzHughNagumoMass))
-        self.assertDictEqual(fhn.parameters, DEFAULT_PARAMS)
+        self.assertDictEqual(fhn.params, DEFAULT_PARAMS)
         coupling_variables = {k: 0.0 for k in fhn.required_couplings}
         self.assertEqual(len(fhn._derivatives(coupling_variables)), fhn.num_state_variables)
         self.assertEqual(len(fhn.initial_state), fhn.num_state_variables)
@@ -73,7 +73,7 @@ class TestFitzHughNagumoNetworkNode(unittest.TestCase):
         fhn = self._create_node()
         self.assertTrue(isinstance(fhn, FitzHughNagumoNetworkNode))
         self.assertEqual(len(fhn), 1)
-        self.assertDictEqual(fhn[0].parameters, DEFAULT_PARAMS)
+        self.assertDictEqual(fhn[0].params, DEFAULT_PARAMS)
         self.assertEqual(len(fhn.default_network_coupling), 2)
         np.testing.assert_equal(np.array(fhn[0].initial_state), fhn.initial_state)
 

--- a/tests/multimodel/test_fitzhugh_nagumo.py
+++ b/tests/multimodel/test_fitzhugh_nagumo.py
@@ -1,0 +1,133 @@
+"""
+Set of tests for FitzHugh-Nagumo model.
+"""
+
+import unittest
+
+import numpy as np
+import xarray as xr
+from jitcdde import jitcdde_input
+from neurolib.models.multimodel.builder.fitzhugh_nagumo import (
+    DEFAULT_PARAMS,
+    FitzHughNagumoMass,
+    FitzHughNagumoNetwork,
+    FitzHughNagumoNetworkNode,
+)
+from neurolib.models.multimodel.builder.model_input import ZeroInput
+
+DURATION = 100.0
+DT = 0.1
+CORR_THRESHOLD = 0.99
+
+# dictionary as backend name: format in which the noise is passed
+BACKENDS_TO_TEST = {
+    "jitcdde": lambda x: x.as_cubic_splines(),
+    "numba": lambda x: x.as_array(),
+}
+
+
+class MassTestCase(unittest.TestCase):
+    def _run_node(self, node, duration, dt):
+        coupling_variables = {k: 0.0 for k in node.required_couplings}
+        noise = ZeroInput(duration, dt, independent_realisations=node.num_noise_variables).as_cubic_splines()
+        system = jitcdde_input(node._derivatives(coupling_variables), input=noise)
+        system.constant_past(np.array(node.initial_state))
+        system.adjust_diff()
+        times = np.arange(dt, duration + dt, dt)
+        return np.vstack([system.integrate(time) for time in times])
+
+
+class TestFitzHughNagumoMass(MassTestCase):
+    def _create_mass(self):
+        fhn = FitzHughNagumoMass()
+        fhn.index = 0
+        fhn.idx_state_var = 0
+        fhn.init_mass()
+        return fhn
+
+    def test_init(self):
+        fhn = self._create_mass()
+        self.assertTrue(isinstance(fhn, FitzHughNagumoMass))
+        self.assertDictEqual(fhn.parameters, DEFAULT_PARAMS)
+        coupling_variables = {k: 0.0 for k in fhn.required_couplings}
+        self.assertEqual(len(fhn._derivatives(coupling_variables)), fhn.num_state_variables)
+        self.assertEqual(len(fhn.initial_state), fhn.num_state_variables)
+        self.assertEqual(len(fhn.noise_input_idx), fhn.num_noise_variables)
+
+    def test_run(self):
+        fhn = self._create_mass()
+        result = self._run_node(fhn, DURATION, DT)
+        self.assertTrue(isinstance(result, np.ndarray))
+        self.assertTupleEqual(result.shape, (int(DURATION / DT), fhn.num_state_variables))
+
+
+class TestFitzHughNagumoNetworkNode(unittest.TestCase):
+    def _create_node(self):
+        node = FitzHughNagumoNetworkNode()
+        node.index = 0
+        node.idx_state_var = 0
+        node.init_node()
+        return node
+
+    def test_init(self):
+        fhn = self._create_node()
+        self.assertTrue(isinstance(fhn, FitzHughNagumoNetworkNode))
+        self.assertEqual(len(fhn), 1)
+        self.assertDictEqual(fhn[0].parameters, DEFAULT_PARAMS)
+        self.assertEqual(len(fhn.default_network_coupling), 2)
+        np.testing.assert_equal(np.array(fhn[0].initial_state), fhn.initial_state)
+
+    def test_run(self):
+        fhn = self._create_node()
+        all_results = []
+        for backend, noise_func in BACKENDS_TO_TEST.items():
+            result = fhn.run(
+                DURATION, DT, noise_func(ZeroInput(DURATION, DT, fhn.num_noise_variables)), backend=backend, dt=DT,
+            )
+            self.assertTrue(isinstance(result, xr.Dataset))
+            self.assertEqual(len(result), fhn.num_state_variables)
+            self.assertTrue(all(state_var in result for state_var in fhn.state_variable_names[0]))
+            self.assertTrue(
+                all(result[state_var].shape == (int(DURATION / DT), 1) for state_var in fhn.state_variable_names[0])
+            )
+            all_results.append(result)
+        # test results are the same from different backends
+        for state_var in all_results[0]:
+            corr_mat = np.corrcoef(
+                np.vstack([result[state_var].values.flatten().astype(float) for result in all_results])
+            )
+            self.assertTrue(np.greater(corr_mat, CORR_THRESHOLD).all())
+
+
+class TestFitzHughNagumoNetwork(unittest.TestCase):
+    SC = np.random.rand(2, 2)
+    DELAYS = np.array([[1.0, 2.0], [2.0, 1.0]])
+
+    def test_init(self):
+        fhn = FitzHughNagumoNetwork(self.SC, self.DELAYS)
+        self.assertTrue(isinstance(fhn, FitzHughNagumoNetwork))
+        self.assertEqual(len(fhn), self.SC.shape[0])
+        self.assertEqual(fhn.initial_state.shape[0], fhn.num_state_variables)
+        self.assertEqual(fhn.default_output, "x")
+
+    def test_run(self):
+        fhn = FitzHughNagumoNetwork(self.SC, self.DELAYS)
+        all_results = []
+        for backend, noise_func in BACKENDS_TO_TEST.items():
+            result = fhn.run(
+                DURATION, DT, noise_func(ZeroInput(DURATION, DT, fhn.num_noise_variables)), backend=backend,
+            )
+            self.assertTrue(isinstance(result, xr.Dataset))
+            self.assertEqual(len(result), fhn.num_state_variables / fhn.num_nodes)
+            self.assertTrue(all(result[result_].shape == (int(DURATION / DT), fhn.num_nodes) for result_ in result))
+            all_results.append(result)
+        # test results are the same from different backends
+        for state_var in all_results[0]:
+            corr_mat = np.corrcoef(
+                np.vstack([result[state_var].values.flatten().astype(float) for result in all_results])
+            )
+            self.assertTrue(np.greater(corr_mat, CORR_THRESHOLD).all())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/multimodel/test_fitzhugh_nagumo.py
+++ b/tests/multimodel/test_fitzhugh_nagumo.py
@@ -1,7 +1,7 @@
 """
 Set of tests for FitzHugh-Nagumo model.
 """
-import numba
+
 import unittest
 
 import numpy as np

--- a/tests/multimodel/test_fitzhugh_nagumo.py
+++ b/tests/multimodel/test_fitzhugh_nagumo.py
@@ -27,7 +27,7 @@ BACKENDS_TO_TEST = {
 
 
 class MassTestCase(unittest.TestCase):
-    def _run_node(self, node, duration, dt):
+    def _run_mass(self, node, duration, dt):
         coupling_variables = {k: 0.0 for k in node.required_couplings}
         noise = ZeroInput(duration, dt, independent_realisations=node.num_noise_variables).as_cubic_splines()
         system = jitcdde_input(node._derivatives(coupling_variables), input=noise)
@@ -56,7 +56,7 @@ class TestFitzHughNagumoMass(MassTestCase):
 
     def test_run(self):
         fhn = self._create_mass()
-        result = self._run_node(fhn, DURATION, DT)
+        result = self._run_mass(fhn, DURATION, DT)
         self.assertTrue(isinstance(result, np.ndarray))
         self.assertTupleEqual(result.shape, (int(DURATION / DT), fhn.num_state_variables))
 

--- a/tests/multimodel/test_fitzhugh_nagumo.py
+++ b/tests/multimodel/test_fitzhugh_nagumo.py
@@ -3,7 +3,7 @@ Set of tests for FitzHugh-Nagumo model.
 """
 
 import unittest
-import numba
+
 import numpy as np
 import xarray as xr
 from jitcdde import jitcdde_input

--- a/tests/multimodel/test_fitzhugh_nagumo.py
+++ b/tests/multimodel/test_fitzhugh_nagumo.py
@@ -152,7 +152,7 @@ class TestFitzHughNagumoNetwork(unittest.TestCase):
         Compare with neurolib's native FitzHugh-Nagumo model.
         """
         # run this model - default is diffusive coupling
-        fhn_multi = FitzHughNagumoNetwork(self.SC, self.DELAYS, x_coupling="diffusive", seed=SEED)
+        fhn_multi = FitzHughNagumoNetwork(self.SC, self.DELAYS, seed=SEED)
         multi_result = fhn_multi.run(DURATION, DT, ZeroInput(DURATION, DT).as_array(), backend="numba")
         # run neurolib's model
         fhn_neurolib = FHNModel(Cmat=self.SC, Dmat=self.DELAYS, seed=SEED)

--- a/tests/multimodel/test_hopf.py
+++ b/tests/multimodel/test_hopf.py
@@ -146,24 +146,23 @@ class TestHopfNetwork(unittest.TestCase):
         Compare with neurolib's native Hopf model.
         """
         # run this model - default is diffusive coupling
-        fhn_multi = HopfNetwork(self.SC, self.DELAYS, x_coupling="diffusive", seed=SEED)
-        multi_result = fhn_multi.run(DURATION, DT, ZeroInput(DURATION, DT).as_array(), backend="numba")
+        hopf_multi = HopfNetwork(self.SC, self.DELAYS, x_coupling="diffusive", seed=SEED)
+        multi_result = hopf_multi.run(DURATION, DT, ZeroInput(DURATION, DT).as_array(), backend="numba")
         # run neurolib's model
-        fhn_neurolib = HopfModel(Cmat=self.SC, Dmat=self.DELAYS, seed=SEED)
-        fhn_neurolib.params["duration"] = DURATION
-        fhn_neurolib.params["dt"] = DT
+        hopf_neurolib = HopfModel(Cmat=self.SC, Dmat=self.DELAYS, seed=SEED)
+        hopf_neurolib.params["duration"] = DURATION
+        hopf_neurolib.params["dt"] = DT
         # there is no "global coupling" parameter in MultiModel
-        fhn_neurolib.params["K_gl"] = 1.0
+        hopf_neurolib.params["K_gl"] = 1.0
         # delays <-> length matrix
-        fhn_neurolib.params["signalV"] = 1.0
-        fhn_neurolib.params["coupling"] = "diffusive"
-        fhn_neurolib.params["sigma_ou"] = 0.0
-        fhn_neurolib.params["xs_init"] = fhn_multi.initial_state[::2][:, np.newaxis]
-        fhn_neurolib.params["ys_init"] = fhn_multi.initial_state[1::2][:, np.newaxis]
-        fhn_neurolib.run()
+        hopf_neurolib.params["signalV"] = 1.0
+        hopf_neurolib.params["coupling"] = "diffusive"
+        hopf_neurolib.params["sigma_ou"] = 0.0
+        hopf_neurolib.params["xs_init"] = hopf_multi.initial_state[::2][:, np.newaxis]
+        hopf_neurolib.params["ys_init"] = hopf_multi.initial_state[1::2][:, np.newaxis]
+        hopf_neurolib.run()
         for var in NEUROLIB_VARIABLES_TO_TEST:
-            corr_mat = np.corrcoef(fhn_neurolib[var], multi_result[var].values.T)
-            print(corr_mat)
+            corr_mat = np.corrcoef(hopf_neurolib[var], multi_result[var].values.T)
             self.assertTrue(np.greater(corr_mat, CORR_THRESHOLD).all())
 
 

--- a/tests/multimodel/test_hopf.py
+++ b/tests/multimodel/test_hopf.py
@@ -146,7 +146,7 @@ class TestHopfNetwork(unittest.TestCase):
         Compare with neurolib's native Hopf model.
         """
         # run this model - default is diffusive coupling
-        hopf_multi = HopfNetwork(self.SC, self.DELAYS, x_coupling="diffusive", seed=SEED)
+        hopf_multi = HopfNetwork(self.SC, self.DELAYS, seed=SEED)
         multi_result = hopf_multi.run(DURATION, DT, ZeroInput(DURATION, DT).as_array(), backend="numba")
         # run neurolib's model
         hopf_neurolib = HopfModel(Cmat=self.SC, Dmat=self.DELAYS, seed=SEED)

--- a/tests/multimodel/test_hopf.py
+++ b/tests/multimodel/test_hopf.py
@@ -7,7 +7,7 @@ import numpy as np
 import xarray as xr
 from jitcdde import jitcdde_input
 from neurolib.models.hopf import HopfModel
-from neurolib.models.multimodel.builder.hopf import DEFAULT_PARAMS, HopfMass, HopfNetwork, HopfNetworkNode
+from neurolib.models.multimodel.builder.hopf import DEFAULT_PARAMS, HopfMass, HopfNetwork, HopfNode
 from neurolib.models.multimodel.builder.model_input import ZeroInput
 
 SEED = 42
@@ -58,9 +58,9 @@ class TestHopfMass(MassTestCase):
         self.assertTupleEqual(result.shape, (int(DURATION / DT), hopf.num_state_variables))
 
 
-class TestHopfNetworkNode(unittest.TestCase):
+class TestHopfNode(unittest.TestCase):
     def _create_node(self):
-        node = HopfNetworkNode(seed=SEED)
+        node = HopfNode(seed=SEED)
         node.index = 0
         node.idx_state_var = 0
         node.init_node()
@@ -68,7 +68,7 @@ class TestHopfNetworkNode(unittest.TestCase):
 
     def test_init(self):
         hopf = self._create_node()
-        self.assertTrue(isinstance(hopf, HopfNetworkNode))
+        self.assertTrue(isinstance(hopf, HopfNode))
         self.assertEqual(len(hopf), 1)
         self.assertDictEqual(hopf[0].params, DEFAULT_PARAMS)
         self.assertEqual(len(hopf.default_network_coupling), 2)

--- a/tests/multimodel/test_thalamus.py
+++ b/tests/multimodel/test_thalamus.py
@@ -11,9 +11,9 @@ from neurolib.models.multimodel.builder.model_input import ZeroInput
 from neurolib.models.multimodel.builder.thalamus import (
     DEFAULT_PARAMS_TCR,
     DEFAULT_PARAMS_TRN,
-    ThalamicNetworkNode,
-    ThalamicReticularPopulation,
-    ThalamocorticalPopulation,
+    ThalamicNode,
+    ThalamicReticularMass,
+    ThalamocorticalMass,
 )
 from neurolib.models.thalamus import ThalamicMassModel
 
@@ -47,14 +47,14 @@ class MassTestCase(unittest.TestCase):
 
 class TestThalamicMass(MassTestCase):
     def _create_tcr_mass(self):
-        tcr = ThalamocorticalPopulation()
+        tcr = ThalamocorticalMass()
         tcr.index = 0
         tcr.idx_state_var = 0
         tcr.init_mass()
         return tcr
 
     def _create_trn_mass(self):
-        trn = ThalamicReticularPopulation()
+        trn = ThalamicReticularMass()
         trn.index = 0
         trn.idx_state_var = 0
         trn.init_mass()
@@ -63,8 +63,8 @@ class TestThalamicMass(MassTestCase):
     def test_init(self):
         tcr = self._create_tcr_mass()
         trn = self._create_trn_mass()
-        self.assertTrue(isinstance(tcr, ThalamocorticalPopulation))
-        self.assertTrue(isinstance(trn, ThalamicReticularPopulation))
+        self.assertTrue(isinstance(tcr, ThalamocorticalMass))
+        self.assertTrue(isinstance(trn, ThalamicReticularMass))
         self.assertDictEqual(tcr.params, DEFAULT_PARAMS_TCR)
         self.assertDictEqual(trn.params, DEFAULT_PARAMS_TRN)
         for thlm in [tcr, trn]:
@@ -84,9 +84,9 @@ class TestThalamicMass(MassTestCase):
             self.assertTupleEqual(result.shape, (int(DURATION / DT), thlm.num_state_variables))
 
 
-class TestThalamicNetworkNode(unittest.TestCase):
+class TestThalamicNode(unittest.TestCase):
     def _create_node(self):
-        node = ThalamicNetworkNode()
+        node = ThalamicNode()
         node.index = 0
         node.idx_state_var = 0
         node.init_node()
@@ -94,7 +94,7 @@ class TestThalamicNetworkNode(unittest.TestCase):
 
     def test_init(self):
         thlm = self._create_node()
-        self.assertTrue(isinstance(thlm, ThalamicNetworkNode))
+        self.assertTrue(isinstance(thlm, ThalamicNode))
         self.assertEqual(len(thlm), 2)
         self.assertDictEqual(thlm[0].params, DEFAULT_PARAMS_TCR)
         self.assertDictEqual(thlm[1].params, DEFAULT_PARAMS_TRN)

--- a/tests/multimodel/test_thalamus.py
+++ b/tests/multimodel/test_thalamus.py
@@ -29,7 +29,7 @@ BACKENDS_TO_TEST = {
 
 
 class MassTestCase(unittest.TestCase):
-    def _run_node(self, node, duration, dt):
+    def _run_mass(self, node, duration, dt):
         coupling_variables = {k: 0.0 for k in node.required_couplings}
         noise = ZeroInput(duration, dt, independent_realisations=node.num_noise_variables).as_cubic_splines()
         system = jitcdde_input(node._derivatives(coupling_variables), input=noise)
@@ -73,7 +73,7 @@ class TestThalamicMass(MassTestCase):
         tcr = self._create_tcr_mass()
         trn = self._create_trn_mass()
         for thlm in [tcr, trn]:
-            result = self._run_node(thlm, DURATION, DT)
+            result = self._run_mass(thlm, DURATION, DT)
             self.assertTrue(isinstance(result, np.ndarray))
             self.assertTupleEqual(result.shape, (int(DURATION / DT), thlm.num_state_variables))
 

--- a/tests/multimodel/test_thalamus.py
+++ b/tests/multimodel/test_thalamus.py
@@ -1,0 +1,132 @@
+"""
+Set of tests for thalamus mass models.
+"""
+
+import unittest
+
+import numpy as np
+import xarray as xr
+from jitcdde import jitcdde_input
+from neurolib.models.multimodel.builder.model_input import ZeroInput
+from neurolib.models.multimodel.builder.thalamus import (
+    DEFAULT_PARAMS_TCR,
+    DEFAULT_PARAMS_TRN,
+    ThalamicNetworkNode,
+    ThalamicReticularPopulation,
+    ThalamocorticalPopulation,
+)
+
+DURATION = 100.0
+SPIN_UP = 1.0
+DT = 0.01
+CORR_THRESHOLD = 0.99
+
+# dictionary as backend name: format in which the noise is passed
+BACKENDS_TO_TEST = {
+    "jitcdde": lambda x: x.as_cubic_splines(),
+    "numba": lambda x: x.as_array(),
+}
+
+
+class MassTestCase(unittest.TestCase):
+    def _run_node(self, node, duration, dt):
+        coupling_variables = {k: 0.0 for k in node.required_couplings}
+        noise = ZeroInput(duration, dt, independent_realisations=node.num_noise_variables).as_cubic_splines()
+        system = jitcdde_input(node._derivatives(coupling_variables), input=noise)
+        system.constant_past(np.array(node.initial_state))
+        system.adjust_diff()
+        times = np.arange(dt, duration + dt, dt)
+        return np.vstack([system.integrate(time) for time in times])
+
+
+class TestThalamicMass(MassTestCase):
+    def _create_tcr_mass(self):
+        tcr = ThalamocorticalPopulation()
+        tcr.index = 0
+        tcr.idx_state_var = 0
+        tcr.init_mass()
+        return tcr
+
+    def _create_trn_mass(self):
+        trn = ThalamicReticularPopulation()
+        trn.index = 0
+        trn.idx_state_var = 0
+        trn.init_mass()
+        return trn
+
+    def test_init(self):
+        tcr = self._create_tcr_mass()
+        trn = self._create_trn_mass()
+        self.assertTrue(isinstance(tcr, ThalamocorticalPopulation))
+        self.assertTrue(isinstance(trn, ThalamicReticularPopulation))
+        self.assertDictEqual(tcr.params, DEFAULT_PARAMS_TCR)
+        self.assertDictEqual(trn.params, DEFAULT_PARAMS_TRN)
+        for thlm in [tcr, trn]:
+            coupling_variables = {k: 0.0 for k in thlm.required_couplings}
+            self.assertEqual(
+                len(thlm._derivatives(coupling_variables)), thlm.num_state_variables,
+            )
+            self.assertEqual(len(thlm.initial_state), thlm.num_state_variables)
+            self.assertEqual(len(thlm.noise_input_idx), thlm.num_noise_variables)
+
+    def test_run(self):
+        tcr = self._create_tcr_mass()
+        trn = self._create_trn_mass()
+        for thlm in [tcr, trn]:
+            result = self._run_node(thlm, DURATION, DT)
+            self.assertTrue(isinstance(result, np.ndarray))
+            self.assertTupleEqual(result.shape, (int(DURATION / DT), thlm.num_state_variables))
+
+
+class TestThalamicNetworkNode(unittest.TestCase):
+    def _create_node(self):
+        node = ThalamicNetworkNode()
+        node.index = 0
+        node.idx_state_var = 0
+        node.init_node()
+        return node
+
+    def test_init(self):
+        thlm = self._create_node()
+        self.assertTrue(isinstance(thlm, ThalamicNetworkNode))
+        self.assertEqual(len(thlm), 2)
+        self.assertDictEqual(thlm[0].params, DEFAULT_PARAMS_TCR)
+        self.assertDictEqual(thlm[1].params, DEFAULT_PARAMS_TRN)
+        self.assertEqual(len(thlm.default_network_coupling), 2)
+        np.testing.assert_equal(
+            np.array(sum([thlmm.initial_state for thlmm in thlm], [])), thlm.initial_state,
+        )
+
+    def test_run(self):
+        thlm = self._create_node()
+        all_results = []
+        for backend, noise_func in BACKENDS_TO_TEST.items():
+            result = thlm.run(
+                DURATION,
+                DT,
+                noise_func(ZeroInput(DURATION + SPIN_UP, DT, thlm.num_noise_variables)),
+                time_spin_up=SPIN_UP,
+                backend=backend,
+                dt=DT,
+            )
+            self.assertTrue(isinstance(result, xr.Dataset))
+            self.assertEqual(len(result), thlm.num_state_variables)
+            self.assertTrue(all(state_var in result for state_var in thlm.state_variable_names[0]))
+            self.assertTrue(
+                all(result[state_var].shape == (int(DURATION / DT), 1) for state_var in thlm.state_variable_names[0])
+            )
+            all_results.append(result)
+        # test results are the same from different backends
+        for state_var in all_results[0]:
+            corr_mat = np.corrcoef(
+                np.vstack([result[state_var].values.flatten().astype(float) for result in all_results])
+            )
+            if not np.any(np.isnan(corr_mat)):
+                # some variables have zero variance (i.e. excitatory synaptic
+                # activity to the TCR - it does not have any in isolated mode
+                # without noise)
+                self.assertTrue(np.greater(corr_mat, CORR_THRESHOLD).all())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/multimodel/test_wilson_cowan.py
+++ b/tests/multimodel/test_wilson_cowan.py
@@ -3,7 +3,7 @@ Set of tests for Wilson-Cowan model.
 """
 
 import unittest
-import numba
+
 import numpy as np
 import xarray as xr
 from jitcdde import jitcdde_input

--- a/tests/multimodel/test_wilson_cowan.py
+++ b/tests/multimodel/test_wilson_cowan.py
@@ -15,7 +15,7 @@ from neurolib.models.multimodel.builder.wilson_cowan import (
     ExcitatoryWilsonCowanMass,
     InhibitoryWilsonCowanMass,
     WilsonCowanNetwork,
-    WilsonCowanNetworkNode,
+    WilsonCowanNode,
 )
 from neurolib.models.wc import WCModel
 
@@ -80,9 +80,9 @@ class TestWilsonCowanMass(MassTestCase):
             self.assertTupleEqual(result.shape, (int(DURATION / DT), wc.num_state_variables))
 
 
-class TestWilsonCowanNetworkNode(unittest.TestCase):
+class TestWilsonCowanNode(unittest.TestCase):
     def _create_node(self):
-        node = WilsonCowanNetworkNode(exc_seed=SEED, inh_seed=SEED)
+        node = WilsonCowanNode(exc_seed=SEED, inh_seed=SEED)
         node.index = 0
         node.idx_state_var = 0
         node.init_node()
@@ -90,7 +90,7 @@ class TestWilsonCowanNetworkNode(unittest.TestCase):
 
     def test_init(self):
         wc = self._create_node()
-        self.assertTrue(isinstance(wc, WilsonCowanNetworkNode))
+        self.assertTrue(isinstance(wc, WilsonCowanNode))
         self.assertEqual(len(wc), 2)
         self.assertDictEqual(wc[0].params, DEFAULT_PARAMS_EXC)
         self.assertDictEqual(wc[1].params, DEFAULT_PARAMS_INH)

--- a/tests/multimodel/test_wilson_cowan.py
+++ b/tests/multimodel/test_wilson_cowan.py
@@ -1,0 +1,148 @@
+"""
+Set of tests for Wilson-Cowan model.
+"""
+
+import unittest
+
+import numpy as np
+import xarray as xr
+from jitcdde import jitcdde_input
+from neurolib.models.multimodel.builder.base.constants import EXC
+from neurolib.models.multimodel.builder.model_input import ZeroInput
+from neurolib.models.multimodel.builder.wilson_cowan import (
+    DEFAULT_PARAMS_EXC,
+    DEFAULT_PARAMS_INH,
+    ExcitatoryWilsonCowanMass,
+    InhibitoryWilsonCowanMass,
+    WilsonCowanNetwork,
+    WilsonCowanNetworkNode,
+)
+
+DURATION = 100.0
+DT = 0.1
+CORR_THRESHOLD = 0.99
+
+# dictionary as backend name: format in which the noise is passed
+BACKENDS_TO_TEST = {
+    "jitcdde": lambda x: x.as_cubic_splines(),
+    "numba": lambda x: x.as_array(),
+}
+
+
+class MassTestCase(unittest.TestCase):
+    def _run_node(self, node, duration, dt):
+        coupling_variables = {k: 0.0 for k in node.required_couplings}
+        noise = ZeroInput(duration, dt, independent_realisations=node.num_noise_variables).as_cubic_splines()
+        system = jitcdde_input(node._derivatives(coupling_variables), input=noise)
+        system.constant_past(np.array(node.initial_state))
+        system.adjust_diff()
+        times = np.arange(dt, duration + dt, dt)
+        return np.vstack([system.integrate(time) for time in times])
+
+
+class TestWilsonCowanMass(MassTestCase):
+    def _create_exc_mass(self):
+        exc = ExcitatoryWilsonCowanMass()
+        exc.index = 0
+        exc.idx_state_var = 0
+        exc.init_mass()
+        return exc
+
+    def _create_inh_mass(self):
+        inh = InhibitoryWilsonCowanMass()
+        inh.index = 0
+        inh.idx_state_var = 0
+        inh.init_mass()
+        return inh
+
+    def test_init(self):
+        wc_exc = self._create_exc_mass()
+        wc_inh = self._create_inh_mass()
+        self.assertTrue(isinstance(wc_exc, ExcitatoryWilsonCowanMass))
+        self.assertTrue(isinstance(wc_inh, InhibitoryWilsonCowanMass))
+        self.assertDictEqual(wc_exc.params, DEFAULT_PARAMS_EXC)
+        self.assertDictEqual(wc_inh.params, DEFAULT_PARAMS_INH)
+        for wc in [wc_exc, wc_inh]:
+            coupling_variables = {k: 0.0 for k in wc.required_couplings}
+            self.assertEqual(len(wc._derivatives(coupling_variables)), wc.num_state_variables)
+            self.assertEqual(len(wc.initial_state), wc.num_state_variables)
+            self.assertEqual(len(wc.noise_input_idx), wc.num_noise_variables)
+
+    def test_run(self):
+        wc_exc = self._create_exc_mass()
+        wc_inh = self._create_inh_mass()
+        for wc in [wc_exc, wc_inh]:
+            result = self._run_node(wc, DURATION, DT)
+            self.assertTrue(isinstance(result, np.ndarray))
+            self.assertTupleEqual(result.shape, (int(DURATION / DT), wc.num_state_variables))
+
+
+class TestWilsonCowanNetworkNode(unittest.TestCase):
+    def _create_node(self):
+        node = WilsonCowanNetworkNode()
+        node.index = 0
+        node.idx_state_var = 0
+        node.init_node()
+        return node
+
+    def test_init(self):
+        wc = self._create_node()
+        self.assertTrue(isinstance(wc, WilsonCowanNetworkNode))
+        self.assertEqual(len(wc), 2)
+        self.assertDictEqual(wc[0].params, DEFAULT_PARAMS_EXC)
+        self.assertDictEqual(wc[1].params, DEFAULT_PARAMS_INH)
+        self.assertEqual(len(wc.default_network_coupling), 1)
+        np.testing.assert_equal(
+            np.array(sum([wcm.initial_state for wcm in wc], [])), wc.initial_state,
+        )
+
+    def test_run(self):
+        wc = self._create_node()
+        all_results = []
+        for backend, noise_func in BACKENDS_TO_TEST.items():
+            result = wc.run(DURATION, DT, noise_func(ZeroInput(DURATION, DT, wc.num_noise_variables)), backend=backend,)
+            self.assertTrue(isinstance(result, xr.Dataset))
+            self.assertEqual(len(result), wc.num_state_variables)
+            self.assertTrue(all(state_var in result for state_var in wc.state_variable_names[0]))
+            self.assertTrue(
+                all(result[state_var].shape == (int(DURATION / DT), 1) for state_var in wc.state_variable_names[0])
+            )
+            all_results.append(result)
+        # test results are the same from different backends
+        for state_var in all_results[0]:
+            corr_mat = np.corrcoef(
+                np.vstack([result[state_var].values.flatten().astype(float) for result in all_results])
+            )
+            self.assertTrue(np.greater(corr_mat, CORR_THRESHOLD).all())
+
+
+class TestWilsonCowanNetwork(unittest.TestCase):
+    SC = np.random.rand(2, 2)
+    DELAYS = np.zeros((2, 2))
+
+    def test_init(self):
+        wc = WilsonCowanNetwork(self.SC, self.DELAYS)
+        self.assertTrue(isinstance(wc, WilsonCowanNetwork))
+        self.assertEqual(len(wc), self.SC.shape[0])
+        self.assertEqual(wc.initial_state.shape[0], wc.num_state_variables)
+        self.assertEqual(wc.default_output, f"q_mean_{EXC}")
+
+    def test_run(self):
+        wc = WilsonCowanNetwork(self.SC, self.DELAYS)
+        all_results = []
+        for backend, noise_func in BACKENDS_TO_TEST.items():
+            result = wc.run(DURATION, DT, noise_func(ZeroInput(DURATION, DT, wc.num_noise_variables)), backend=backend,)
+            self.assertTrue(isinstance(result, xr.Dataset))
+            self.assertEqual(len(result), wc.num_state_variables / wc.num_nodes)
+            self.assertTrue(all(result[result_].shape == (int(DURATION / DT), wc.num_nodes) for result_ in result))
+            all_results.append(result)
+        # test results are the same from different backends
+        for state_var in all_results[0]:
+            corr_mat = np.corrcoef(
+                np.vstack([result[state_var].values.flatten().astype(float) for result in all_results])
+            )
+            self.assertTrue(np.greater(corr_mat, CORR_THRESHOLD).all())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/multimodel/test_wilson_cowan.py
+++ b/tests/multimodel/test_wilson_cowan.py
@@ -30,7 +30,7 @@ BACKENDS_TO_TEST = {
 
 
 class MassTestCase(unittest.TestCase):
-    def _run_node(self, node, duration, dt):
+    def _run_mass(self, node, duration, dt):
         coupling_variables = {k: 0.0 for k in node.required_couplings}
         noise = ZeroInput(duration, dt, independent_realisations=node.num_noise_variables).as_cubic_splines()
         system = jitcdde_input(node._derivatives(coupling_variables), input=noise)
@@ -72,7 +72,7 @@ class TestWilsonCowanMass(MassTestCase):
         wc_exc = self._create_exc_mass()
         wc_inh = self._create_inh_mass()
         for wc in [wc_exc, wc_inh]:
-            result = self._run_node(wc, DURATION, DT)
+            result = self._run_mass(wc, DURATION, DT)
             self.assertTrue(isinstance(result, np.ndarray))
             self.assertTupleEqual(result.shape, (int(DURATION / DT), wc.num_state_variables))
 

--- a/tests/multimodel/test_wilson_cowan.py
+++ b/tests/multimodel/test_wilson_cowan.py
@@ -3,7 +3,7 @@ Set of tests for Wilson-Cowan model.
 """
 
 import unittest
-
+import numba
 import numpy as np
 import xarray as xr
 from jitcdde import jitcdde_input
@@ -94,7 +94,7 @@ class TestWilsonCowanNetworkNode(unittest.TestCase):
         self.assertEqual(len(wc), 2)
         self.assertDictEqual(wc[0].params, DEFAULT_PARAMS_EXC)
         self.assertDictEqual(wc[1].params, DEFAULT_PARAMS_INH)
-        self.assertEqual(len(wc.default_network_coupling), 1)
+        self.assertEqual(len(wc.default_network_coupling), 2)
         np.testing.assert_equal(
             np.array(sum([wcm.initial_state for wcm in wc], [])), wc.initial_state,
         )

--- a/tests/multimodel/test_wong_wang.py
+++ b/tests/multimodel/test_wong_wang.py
@@ -1,0 +1,181 @@
+"""
+Set of tests for Wong-Wang model.
+"""
+
+import unittest
+
+import numpy as np
+import xarray as xr
+from jitcdde import jitcdde_input
+
+# from neurolib.models.multimodel.builder.base.constants import EXC
+from neurolib.models.multimodel.builder.model_input import ZeroInput
+from neurolib.models.multimodel.builder.wong_wang import (
+    DEFAULT_PARAMS_EXC,
+    DEFAULT_PARAMS_INH,
+    DEFAULT_PARAMS_REDUCED,
+    ExcitatoryWongWangMass,
+    InhibitoryWongWangMass,
+    ReducedWongWangMass,
+    WongWangNetworkNode,
+    ReducedWongWangNetworkNode,
+)
+
+DURATION = 100.0
+DT = 0.1
+CORR_THRESHOLD = 0.99
+
+# dictionary as backend name: format in which the noise is passed
+BACKENDS_TO_TEST = {
+    "jitcdde": lambda x: x.as_cubic_splines(),
+    "numba": lambda x: x.as_array(),
+}
+
+
+class MassTestCase(unittest.TestCase):
+    def _run_mass(self, node, duration, dt):
+        coupling_variables = {k: 0.0 for k in node.required_couplings}
+        noise = ZeroInput(duration, dt, independent_realisations=node.num_noise_variables).as_cubic_splines()
+        system = jitcdde_input(node._derivatives(coupling_variables), input=noise)
+        system.constant_past(np.array(node.initial_state))
+        system.adjust_diff()
+        times = np.arange(dt, duration + dt, dt)
+        return np.vstack([system.integrate(time) for time in times])
+
+
+class TestWongWangMass(MassTestCase):
+    def _create_exc_mass(self):
+        exc = ExcitatoryWongWangMass()
+        exc.index = 0
+        exc.idx_state_var = 0
+        exc.init_mass()
+        return exc
+
+    def _create_inh_mass(self):
+        inh = InhibitoryWongWangMass()
+        inh.index = 0
+        inh.idx_state_var = 0
+        inh.init_mass()
+        return inh
+
+    def test_init(self):
+        ww_exc = self._create_exc_mass()
+        ww_inh = self._create_inh_mass()
+        self.assertTrue(isinstance(ww_exc, ExcitatoryWongWangMass))
+        self.assertTrue(isinstance(ww_inh, InhibitoryWongWangMass))
+        self.assertDictEqual(ww_exc.params, DEFAULT_PARAMS_EXC)
+        self.assertDictEqual(ww_inh.params, DEFAULT_PARAMS_INH)
+        for ww in [ww_exc, ww_inh]:
+            coupling_variables = {k: 0.0 for k in ww.required_couplings}
+            self.assertEqual(len(ww._derivatives(coupling_variables)), ww.num_state_variables)
+            self.assertEqual(len(ww.initial_state), ww.num_state_variables)
+            self.assertEqual(len(ww.noise_input_idx), ww.num_noise_variables)
+
+    def test_run(self):
+        ww_exc = self._create_exc_mass()
+        ww_inh = self._create_inh_mass()
+        for ww in [ww_exc, ww_inh]:
+            result = self._run_mass(ww, DURATION, DT)
+            self.assertTrue(isinstance(result, np.ndarray))
+            self.assertTupleEqual(result.shape, (int(DURATION / DT), ww.num_state_variables))
+
+
+class TestReducedWongWangMass(MassTestCase):
+    def _create_mass(self):
+        rww = ReducedWongWangMass()
+        rww.index = 0
+        rww.idx_state_var = 0
+        rww.init_mass()
+        return rww
+
+    def test_init(self):
+        rww = self._create_mass()
+        self.assertTrue(isinstance(rww, ReducedWongWangMass))
+        self.assertDictEqual(rww.params, DEFAULT_PARAMS_REDUCED)
+        coupling_variables = {k: 0.0 for k in rww.required_couplings}
+        self.assertEqual(len(rww._derivatives(coupling_variables)), rww.num_state_variables)
+        self.assertEqual(len(rww.initial_state), rww.num_state_variables)
+        self.assertEqual(len(rww.noise_input_idx), rww.num_noise_variables)
+
+    def test_run(self):
+        rww = self._create_mass()
+        result = self._run_mass(rww, DURATION, DT)
+        self.assertTrue(isinstance(result, np.ndarray))
+        self.assertTupleEqual(result.shape, (int(DURATION / DT), rww.num_state_variables))
+
+
+class TestWongWangNetworkNode(unittest.TestCase):
+    def _create_node(self):
+        node = WongWangNetworkNode()
+        node.index = 0
+        node.idx_state_var = 0
+        node.init_node()
+        return node
+
+    def test_init(self):
+        ww = self._create_node()
+        self.assertTrue(isinstance(ww, WongWangNetworkNode))
+        self.assertEqual(len(ww), 2)
+        self.assertDictEqual(ww[0].params, DEFAULT_PARAMS_EXC)
+        self.assertDictEqual(ww[1].params, DEFAULT_PARAMS_INH)
+        self.assertEqual(len(ww.default_network_coupling), 1)
+        np.testing.assert_equal(
+            np.array(sum([wwm.initial_state for wwm in ww], [])), ww.initial_state,
+        )
+
+    def test_run(self):
+        ww = self._create_node()
+        all_results = []
+        for backend, noise_func in BACKENDS_TO_TEST.items():
+            result = ww.run(DURATION, DT, noise_func(ZeroInput(DURATION, DT, ww.num_noise_variables)), backend=backend,)
+            self.assertTrue(isinstance(result, xr.Dataset))
+            self.assertEqual(len(result), ww.num_state_variables)
+            self.assertTrue(all(state_var in result for state_var in ww.state_variable_names[0]))
+            self.assertTrue(
+                all(result[state_var].shape == (int(DURATION / DT), 1) for state_var in ww.state_variable_names[0])
+            )
+            all_results.append(result)
+        # test results are the same from different backends
+        for state_var in all_results[0]:
+            corr_mat = np.corrcoef(
+                np.vstack([result[state_var].values.flatten().astype(float) for result in all_results])
+            )
+            self.assertTrue(np.greater(corr_mat, CORR_THRESHOLD).all())
+
+
+class TestReducedWongWangNetworkNode(unittest.TestCase):
+    def _create_node(self):
+        node = ReducedWongWangNetworkNode()
+        node.index = 0
+        node.idx_state_var = 0
+        node.init_node()
+        return node
+
+    def test_init(self):
+        rww = self._create_node()
+        self.assertTrue(isinstance(rww, ReducedWongWangNetworkNode))
+        self.assertEqual(len(rww), 1)
+        self.assertDictEqual(rww[0].params, DEFAULT_PARAMS_REDUCED)
+        self.assertEqual(len(rww.default_network_coupling), 2)
+        np.testing.assert_equal(np.array(rww[0].initial_state), rww.initial_state)
+
+    def test_run(self):
+        rww = self._create_node()
+        all_results = []
+        for backend, noise_func in BACKENDS_TO_TEST.items():
+            result = rww.run(
+                DURATION, DT, noise_func(ZeroInput(DURATION, DT, rww.num_noise_variables)), backend=backend, dt=DT,
+            )
+            self.assertTrue(isinstance(result, xr.Dataset))
+            self.assertEqual(len(result), rww.num_state_variables)
+            self.assertTrue(all(state_var in result for state_var in rww.state_variable_names[0]))
+            self.assertTrue(
+                all(result[state_var].shape == (int(DURATION / DT), 1) for state_var in rww.state_variable_names[0])
+            )
+            all_results.append(result)
+        # test results are the same from different backends
+        for state_var in all_results[0]:
+            corr_mat = np.corrcoef(
+                np.vstack([result[state_var].values.flatten().astype(float) for result in all_results])
+            )
+            self.assertTrue(np.greater(corr_mat, CORR_THRESHOLD).all())

--- a/tests/multimodel/test_wong_wang.py
+++ b/tests/multimodel/test_wong_wang.py
@@ -102,80 +102,83 @@ class TestReducedWongWangMass(MassTestCase):
         self.assertTupleEqual(result.shape, (int(DURATION / DT), rww.num_state_variables))
 
 
-class TestWongWangNetworkNode(unittest.TestCase):
-    def _create_node(self):
-        node = WongWangNetworkNode()
-        node.index = 0
-        node.idx_state_var = 0
-        node.init_node()
-        return node
+# class TestWongWangNetworkNode(unittest.TestCase):
+#     def _create_node(self):
+#         node = WongWangNetworkNode()
+#         node.index = 0
+#         node.idx_state_var = 0
+#         node.init_node()
+#         return node
 
-    def test_init(self):
-        ww = self._create_node()
-        self.assertTrue(isinstance(ww, WongWangNetworkNode))
-        self.assertEqual(len(ww), 2)
-        self.assertDictEqual(ww[0].params, DEFAULT_PARAMS_EXC)
-        self.assertDictEqual(ww[1].params, DEFAULT_PARAMS_INH)
-        self.assertEqual(len(ww.default_network_coupling), 1)
-        np.testing.assert_equal(
-            np.array(sum([wwm.initial_state for wwm in ww], [])), ww.initial_state,
-        )
+#     def test_init(self):
+#         ww = self._create_node()
+#         self.assertTrue(isinstance(ww, WongWangNetworkNode))
+#         self.assertEqual(len(ww), 2)
+#         self.assertDictEqual(ww[0].params, DEFAULT_PARAMS_EXC)
+#         self.assertDictEqual(ww[1].params, DEFAULT_PARAMS_INH)
+#         self.assertEqual(len(ww.default_network_coupling), 1)
+#         np.testing.assert_equal(
+#             np.array(sum([wwm.initial_state for wwm in ww], [])), ww.initial_state,
+#         )
 
-    def test_run(self):
-        ww = self._create_node()
-        all_results = []
-        for backend, noise_func in BACKENDS_TO_TEST.items():
-            result = ww.run(DURATION, DT, noise_func(ZeroInput(DURATION, DT, ww.num_noise_variables)), backend=backend,)
-            self.assertTrue(isinstance(result, xr.Dataset))
-            self.assertEqual(len(result), ww.num_state_variables)
-            self.assertTrue(all(state_var in result for state_var in ww.state_variable_names[0]))
-            self.assertTrue(
-                all(result[state_var].shape == (int(DURATION / DT), 1) for state_var in ww.state_variable_names[0])
-            )
-            all_results.append(result)
-        # test results are the same from different backends
-        for state_var in all_results[0]:
-            corr_mat = np.corrcoef(
-                np.vstack([result[state_var].values.flatten().astype(float) for result in all_results])
-            )
-            print(corr_mat)
-            self.assertTrue(np.greater(corr_mat, CORR_THRESHOLD).all())
+#     def test_run(self):
+#         ww = self._create_node()
+#         all_results = []
+#         for backend, noise_func in BACKENDS_TO_TEST.items():
+#             result = ww.run(DURATION, DT, noise_func(ZeroInput(DURATION, DT, ww.num_noise_variables)), backend=backend,)
+#             self.assertTrue(isinstance(result, xr.Dataset))
+#             self.assertEqual(len(result), ww.num_state_variables)
+#             self.assertTrue(all(state_var in result for state_var in ww.state_variable_names[0]))
+#             self.assertTrue(
+#                 all(result[state_var].shape == (int(DURATION / DT), 1) for state_var in ww.state_variable_names[0])
+#             )
+#             all_results.append(result)
+#         # test results are the same from different backends
+#         for state_var in all_results[0]:
+#             corr_mat = np.corrcoef(
+#                 np.vstack([result[state_var].values.flatten().astype(float) for result in all_results])
+#             )
+#             print(corr_mat)
+#             self.assertTrue(np.greater(corr_mat, CORR_THRESHOLD).all())
 
 
-class TestReducedWongWangNetworkNode(unittest.TestCase):
-    def _create_node(self):
-        node = ReducedWongWangNetworkNode()
-        node.index = 0
-        node.idx_state_var = 0
-        node.init_node()
-        return node
+# class TestReducedWongWangNetworkNode(unittest.TestCase):
+#     def _create_node(self):
+#         node = ReducedWongWangNetworkNode()
+#         node.index = 0
+#         node.idx_state_var = 0
+#         node.init_node()
+#         return node
 
-    def test_init(self):
-        rww = self._create_node()
-        self.assertTrue(isinstance(rww, ReducedWongWangNetworkNode))
-        self.assertEqual(len(rww), 1)
-        self.assertDictEqual(rww[0].params, DEFAULT_PARAMS_REDUCED)
-        self.assertEqual(len(rww.default_network_coupling), 1)
-        np.testing.assert_equal(np.array(rww[0].initial_state), rww.initial_state)
+#     def test_init(self):
+#         rww = self._create_node()
+#         self.assertTrue(isinstance(rww, ReducedWongWangNetworkNode))
+#         self.assertEqual(len(rww), 1)
+#         self.assertDictEqual(rww[0].params, DEFAULT_PARAMS_REDUCED)
+#         self.assertEqual(len(rww.default_network_coupling), 1)
+#         np.testing.assert_equal(np.array(rww[0].initial_state), rww.initial_state)
 
-    def test_run(self):
-        rww = self._create_node()
-        all_results = []
-        for backend, noise_func in BACKENDS_TO_TEST.items():
-            result = rww.run(
-                DURATION, DT, noise_func(ZeroInput(DURATION, DT, rww.num_noise_variables)), backend=backend, dt=DT,
-            )
-            self.assertTrue(isinstance(result, xr.Dataset))
-            self.assertEqual(len(result), rww.num_state_variables)
-            self.assertTrue(all(state_var in result for state_var in rww.state_variable_names[0]))
-            self.assertTrue(
-                all(result[state_var].shape == (int(DURATION / DT), 1) for state_var in rww.state_variable_names[0])
-            )
-            all_results.append(result)
-        # test results are the same from different backends
-        for state_var in all_results[0]:
-            corr_mat = np.corrcoef(
-                np.vstack([result[state_var].values.flatten().astype(float) for result in all_results])
-            )
-            print(corr_mat)
-            self.assertTrue(np.greater(corr_mat, CORR_THRESHOLD).all())
+#     def test_run(self):
+#         rww = self._create_node()
+#         all_results = []
+#         for backend, noise_func in BACKENDS_TO_TEST.items():
+#             result = rww.run(
+#                 DURATION, DT, noise_func(ZeroInput(DURATION, DT, rww.num_noise_variables)), backend=backend, dt=DT,
+#             )
+#             self.assertTrue(isinstance(result, xr.Dataset))
+#             self.assertEqual(len(result), rww.num_state_variables)
+#             self.assertTrue(all(state_var in result for state_var in rww.state_variable_names[0]))
+#             self.assertTrue(
+#                 all(result[state_var].shape == (int(DURATION / DT), 1) for state_var in rww.state_variable_names[0])
+#             )
+#             all_results.append(result)
+#         # test results are the same from different backends
+#         for state_var in all_results[0]:
+#             corr_mat = np.corrcoef(
+#                 np.vstack([result[state_var].values.flatten().astype(float) for result in all_results])
+#             )
+#             print(corr_mat)
+#             self.assertTrue(np.greater(corr_mat, CORR_THRESHOLD).all())
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/multimodel/test_wong_wang.py
+++ b/tests/multimodel/test_wong_wang.py
@@ -1,12 +1,12 @@
 """
 Set of tests for Wong-Wang model.
 """
-import numba
 import unittest
 
 import numpy as np
 import xarray as xr
 from jitcdde import jitcdde_input
+from neurolib.models.multimodel.builder.base.constants import EXC
 from neurolib.models.multimodel.builder.model_input import ZeroInput
 from neurolib.models.multimodel.builder.wong_wang import (
     DEFAULT_PARAMS_EXC,
@@ -15,13 +15,16 @@ from neurolib.models.multimodel.builder.wong_wang import (
     ExcitatoryWongWangMass,
     InhibitoryWongWangMass,
     ReducedWongWangMass,
+    ReducedWongWangNetwork,
     ReducedWongWangNetworkNode,
+    WongWangNetwork,
     WongWangNetworkNode,
 )
 
+SEED = 42
 DURATION = 100.0
 DT = 0.1
-CORR_THRESHOLD = 0.95
+CORR_THRESHOLD = 0.99
 
 # dictionary as backend name: format in which the noise is passed
 BACKENDS_TO_TEST = {
@@ -102,83 +105,140 @@ class TestReducedWongWangMass(MassTestCase):
         self.assertTupleEqual(result.shape, (int(DURATION / DT), rww.num_state_variables))
 
 
-# class TestWongWangNetworkNode(unittest.TestCase):
-#     def _create_node(self):
-#         node = WongWangNetworkNode()
-#         node.index = 0
-#         node.idx_state_var = 0
-#         node.init_node()
-#         return node
+class TestWongWangNetworkNode(unittest.TestCase):
+    def _create_node(self):
+        node = WongWangNetworkNode(exc_seed=SEED, inh_seed=SEED)
+        node.index = 0
+        node.idx_state_var = 0
+        node.init_node()
+        return node
 
-#     def test_init(self):
-#         ww = self._create_node()
-#         self.assertTrue(isinstance(ww, WongWangNetworkNode))
-#         self.assertEqual(len(ww), 2)
-#         self.assertDictEqual(ww[0].params, DEFAULT_PARAMS_EXC)
-#         self.assertDictEqual(ww[1].params, DEFAULT_PARAMS_INH)
-#         self.assertEqual(len(ww.default_network_coupling), 1)
-#         np.testing.assert_equal(
-#             np.array(sum([wwm.initial_state for wwm in ww], [])), ww.initial_state,
-#         )
+    def test_init(self):
+        ww = self._create_node()
+        self.assertTrue(isinstance(ww, WongWangNetworkNode))
+        self.assertEqual(len(ww), 2)
+        self.assertDictEqual(ww[0].params, DEFAULT_PARAMS_EXC)
+        self.assertDictEqual(ww[1].params, DEFAULT_PARAMS_INH)
+        self.assertEqual(len(ww.default_network_coupling), 1)
+        np.testing.assert_equal(
+            np.array(sum([wwm.initial_state for wwm in ww], [])), ww.initial_state,
+        )
 
-#     def test_run(self):
-#         ww = self._create_node()
-#         all_results = []
-#         for backend, noise_func in BACKENDS_TO_TEST.items():
-#             result = ww.run(DURATION, DT, noise_func(ZeroInput(DURATION, DT, ww.num_noise_variables)), backend=backend,)
-#             self.assertTrue(isinstance(result, xr.Dataset))
-#             self.assertEqual(len(result), ww.num_state_variables)
-#             self.assertTrue(all(state_var in result for state_var in ww.state_variable_names[0]))
-#             self.assertTrue(
-#                 all(result[state_var].shape == (int(DURATION / DT), 1) for state_var in ww.state_variable_names[0])
-#             )
-#             all_results.append(result)
-#         # test results are the same from different backends
-#         for state_var in all_results[0]:
-#             corr_mat = np.corrcoef(
-#                 np.vstack([result[state_var].values.flatten().astype(float) for result in all_results])
-#             )
-#             print(corr_mat)
-#             self.assertTrue(np.greater(corr_mat, CORR_THRESHOLD).all())
+    def test_run(self):
+        ww = self._create_node()
+        all_results = []
+        for backend, noise_func in BACKENDS_TO_TEST.items():
+            result = ww.run(DURATION, DT, noise_func(ZeroInput(DURATION, DT, ww.num_noise_variables)), backend=backend,)
+            self.assertTrue(isinstance(result, xr.Dataset))
+            self.assertEqual(len(result), ww.num_state_variables)
+            self.assertTrue(all(state_var in result for state_var in ww.state_variable_names[0]))
+            self.assertTrue(
+                all(result[state_var].shape == (int(DURATION / DT), 1) for state_var in ww.state_variable_names[0])
+            )
+            all_results.append(result)
+        # test results are the same from different backends
+        for state_var in all_results[0]:
+            corr_mat = np.corrcoef(
+                np.vstack([result[state_var].values.flatten().astype(float) for result in all_results])
+            )
+            self.assertTrue(np.greater(corr_mat, CORR_THRESHOLD).all())
 
 
-# class TestReducedWongWangNetworkNode(unittest.TestCase):
-#     def _create_node(self):
-#         node = ReducedWongWangNetworkNode()
-#         node.index = 0
-#         node.idx_state_var = 0
-#         node.init_node()
-#         return node
+class TestReducedWongWangNetworkNode(unittest.TestCase):
+    def _create_node(self):
+        node = ReducedWongWangNetworkNode(seed=SEED)
+        node.index = 0
+        node.idx_state_var = 0
+        node.init_node()
+        return node
 
-#     def test_init(self):
-#         rww = self._create_node()
-#         self.assertTrue(isinstance(rww, ReducedWongWangNetworkNode))
-#         self.assertEqual(len(rww), 1)
-#         self.assertDictEqual(rww[0].params, DEFAULT_PARAMS_REDUCED)
-#         self.assertEqual(len(rww.default_network_coupling), 1)
-#         np.testing.assert_equal(np.array(rww[0].initial_state), rww.initial_state)
+    def test_init(self):
+        rww = self._create_node()
+        self.assertTrue(isinstance(rww, ReducedWongWangNetworkNode))
+        self.assertEqual(len(rww), 1)
+        self.assertDictEqual(rww[0].params, DEFAULT_PARAMS_REDUCED)
+        self.assertEqual(len(rww.default_network_coupling), 1)
+        np.testing.assert_equal(np.array(rww[0].initial_state), rww.initial_state)
 
-#     def test_run(self):
-#         rww = self._create_node()
-#         all_results = []
-#         for backend, noise_func in BACKENDS_TO_TEST.items():
-#             result = rww.run(
-#                 DURATION, DT, noise_func(ZeroInput(DURATION, DT, rww.num_noise_variables)), backend=backend, dt=DT,
-#             )
-#             self.assertTrue(isinstance(result, xr.Dataset))
-#             self.assertEqual(len(result), rww.num_state_variables)
-#             self.assertTrue(all(state_var in result for state_var in rww.state_variable_names[0]))
-#             self.assertTrue(
-#                 all(result[state_var].shape == (int(DURATION / DT), 1) for state_var in rww.state_variable_names[0])
-#             )
-#             all_results.append(result)
-#         # test results are the same from different backends
-#         for state_var in all_results[0]:
-#             corr_mat = np.corrcoef(
-#                 np.vstack([result[state_var].values.flatten().astype(float) for result in all_results])
-#             )
-#             print(corr_mat)
-#             self.assertTrue(np.greater(corr_mat, CORR_THRESHOLD).all())
+    def test_run(self):
+        rww = self._create_node()
+        all_results = []
+        for backend, noise_func in BACKENDS_TO_TEST.items():
+            result = rww.run(
+                DURATION, DT, noise_func(ZeroInput(DURATION, DT, rww.num_noise_variables)), backend=backend
+            )
+            self.assertTrue(isinstance(result, xr.Dataset))
+            self.assertEqual(len(result), rww.num_state_variables)
+            self.assertTrue(all(state_var in result for state_var in rww.state_variable_names[0]))
+            self.assertTrue(
+                all(result[state_var].shape == (int(DURATION / DT), 1) for state_var in rww.state_variable_names[0])
+            )
+            all_results.append(result)
+        # test results are the same from different backends
+        for state_var in all_results[0]:
+            corr_mat = np.corrcoef(
+                np.vstack([result[state_var].values.flatten().astype(float) for result in all_results])
+            )
+            self.assertTrue(np.greater(corr_mat, CORR_THRESHOLD).all())
+
+
+class TestWongWangNetwork(unittest.TestCase):
+    SC = np.random.rand(2, 2)
+    DELAYS = np.array([[0.0, 0.0], [0.0, 0.0]])
+
+    def test_init(self):
+        ww = WongWangNetwork(self.SC, self.DELAYS)
+        self.assertTrue(isinstance(ww, WongWangNetwork))
+        self.assertEqual(len(ww), self.SC.shape[0])
+        self.assertEqual(ww.initial_state.shape[0], ww.num_state_variables)
+        self.assertEqual(ww.default_output, f"S_{EXC}")
+
+    def test_run(self):
+        ww = WongWangNetwork(self.SC, self.DELAYS, exc_seed=SEED, inh_seed=SEED)
+        all_results = []
+        for backend, noise_func in BACKENDS_TO_TEST.items():
+            result = ww.run(DURATION, DT, noise_func(ZeroInput(DURATION, DT, ww.num_noise_variables)), backend=backend,)
+            self.assertTrue(isinstance(result, xr.Dataset))
+            self.assertEqual(len(result), ww.num_state_variables / ww.num_nodes)
+            self.assertTrue(all(result[result_].shape == (int(DURATION / DT), ww.num_nodes) for result_ in result))
+            all_results.append(result)
+        # test results are the same from different backends
+        for state_var in all_results[0]:
+            corr_mat = np.corrcoef(
+                np.vstack([result[state_var].values.flatten().astype(float) for result in all_results])
+            )
+            self.assertTrue(np.greater(corr_mat, CORR_THRESHOLD).all())
+
+
+class TestReducedWongWangNetwork(unittest.TestCase):
+    SC = np.random.rand(2, 2)
+    DELAYS = np.array([[0.0, 0.0], [0.0, 0.0]])
+
+    def test_init(self):
+        rww = ReducedWongWangNetwork(self.SC, self.DELAYS)
+        self.assertTrue(isinstance(rww, ReducedWongWangNetwork))
+        self.assertEqual(len(rww), self.SC.shape[0])
+        self.assertEqual(rww.initial_state.shape[0], rww.num_state_variables)
+        self.assertEqual(rww.default_output, "S")
+
+    def test_run(self):
+        rww = ReducedWongWangNetwork(self.SC, self.DELAYS, seed=SEED)
+        all_results = []
+        for backend, noise_func in BACKENDS_TO_TEST.items():
+            result = rww.run(
+                DURATION, DT, noise_func(ZeroInput(DURATION, DT, rww.num_noise_variables)), backend=backend,
+            )
+            self.assertTrue(isinstance(result, xr.Dataset))
+            self.assertEqual(len(result), rww.num_state_variables / rww.num_nodes)
+            self.assertTrue(all(result[result_].shape == (int(DURATION / DT), rww.num_nodes) for result_ in result))
+            all_results.append(result)
+        # test results are the same from different backends
+        for state_var in all_results[0]:
+            corr_mat = np.corrcoef(
+                np.vstack([result[state_var].values.flatten().astype(float) for result in all_results])
+            )
+            self.assertTrue(np.greater(corr_mat, CORR_THRESHOLD).all())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/multimodel/test_wong_wang.py
+++ b/tests/multimodel/test_wong_wang.py
@@ -2,7 +2,7 @@
 Set of tests for Wong-Wang model.
 """
 import unittest
-
+import numba
 import numpy as np
 import xarray as xr
 from jitcdde import jitcdde_input
@@ -119,7 +119,7 @@ class TestWongWangNetworkNode(unittest.TestCase):
         self.assertEqual(len(ww), 2)
         self.assertDictEqual(ww[0].params, DEFAULT_PARAMS_EXC)
         self.assertDictEqual(ww[1].params, DEFAULT_PARAMS_INH)
-        self.assertEqual(len(ww.default_network_coupling), 1)
+        self.assertEqual(len(ww.default_network_coupling), 2)
         np.testing.assert_equal(
             np.array(sum([wwm.initial_state for wwm in ww], [])), ww.initial_state,
         )

--- a/tests/multimodel/test_wong_wang.py
+++ b/tests/multimodel/test_wong_wang.py
@@ -2,7 +2,7 @@
 Set of tests for Wong-Wang model.
 """
 import unittest
-import numba
+
 import numpy as np
 import xarray as xr
 from jitcdde import jitcdde_input
@@ -16,9 +16,9 @@ from neurolib.models.multimodel.builder.wong_wang import (
     InhibitoryWongWangMass,
     ReducedWongWangMass,
     ReducedWongWangNetwork,
-    ReducedWongWangNetworkNode,
+    ReducedWongWangNode,
     WongWangNetwork,
-    WongWangNetworkNode,
+    WongWangNode,
 )
 
 SEED = 42
@@ -105,9 +105,9 @@ class TestReducedWongWangMass(MassTestCase):
         self.assertTupleEqual(result.shape, (int(DURATION / DT), rww.num_state_variables))
 
 
-class TestWongWangNetworkNode(unittest.TestCase):
+class TestWongWangNode(unittest.TestCase):
     def _create_node(self):
-        node = WongWangNetworkNode(exc_seed=SEED, inh_seed=SEED)
+        node = WongWangNode(exc_seed=SEED, inh_seed=SEED)
         node.index = 0
         node.idx_state_var = 0
         node.init_node()
@@ -115,7 +115,7 @@ class TestWongWangNetworkNode(unittest.TestCase):
 
     def test_init(self):
         ww = self._create_node()
-        self.assertTrue(isinstance(ww, WongWangNetworkNode))
+        self.assertTrue(isinstance(ww, WongWangNode))
         self.assertEqual(len(ww), 2)
         self.assertDictEqual(ww[0].params, DEFAULT_PARAMS_EXC)
         self.assertDictEqual(ww[1].params, DEFAULT_PARAMS_INH)
@@ -144,9 +144,9 @@ class TestWongWangNetworkNode(unittest.TestCase):
             self.assertTrue(np.greater(corr_mat, CORR_THRESHOLD).all())
 
 
-class TestReducedWongWangNetworkNode(unittest.TestCase):
+class TestReducedWongWangNode(unittest.TestCase):
     def _create_node(self):
-        node = ReducedWongWangNetworkNode(seed=SEED)
+        node = ReducedWongWangNode(seed=SEED)
         node.index = 0
         node.idx_state_var = 0
         node.init_node()
@@ -154,7 +154,7 @@ class TestReducedWongWangNetworkNode(unittest.TestCase):
 
     def test_init(self):
         rww = self._create_node()
-        self.assertTrue(isinstance(rww, ReducedWongWangNetworkNode))
+        self.assertTrue(isinstance(rww, ReducedWongWangNode))
         self.assertEqual(len(rww), 1)
         self.assertDictEqual(rww[0].params, DEFAULT_PARAMS_REDUCED)
         self.assertEqual(len(rww.default_network_coupling), 1)

--- a/tests/multimodel/test_wong_wang.py
+++ b/tests/multimodel/test_wong_wang.py
@@ -1,14 +1,12 @@
 """
 Set of tests for Wong-Wang model.
 """
-
+import numba
 import unittest
 
 import numpy as np
 import xarray as xr
 from jitcdde import jitcdde_input
-
-# from neurolib.models.multimodel.builder.base.constants import EXC
 from neurolib.models.multimodel.builder.model_input import ZeroInput
 from neurolib.models.multimodel.builder.wong_wang import (
     DEFAULT_PARAMS_EXC,
@@ -17,13 +15,13 @@ from neurolib.models.multimodel.builder.wong_wang import (
     ExcitatoryWongWangMass,
     InhibitoryWongWangMass,
     ReducedWongWangMass,
-    WongWangNetworkNode,
     ReducedWongWangNetworkNode,
+    WongWangNetworkNode,
 )
 
 DURATION = 100.0
 DT = 0.1
-CORR_THRESHOLD = 0.99
+CORR_THRESHOLD = 0.95
 
 # dictionary as backend name: format in which the noise is passed
 BACKENDS_TO_TEST = {
@@ -140,6 +138,7 @@ class TestWongWangNetworkNode(unittest.TestCase):
             corr_mat = np.corrcoef(
                 np.vstack([result[state_var].values.flatten().astype(float) for result in all_results])
             )
+            print(corr_mat)
             self.assertTrue(np.greater(corr_mat, CORR_THRESHOLD).all())
 
 
@@ -156,7 +155,7 @@ class TestReducedWongWangNetworkNode(unittest.TestCase):
         self.assertTrue(isinstance(rww, ReducedWongWangNetworkNode))
         self.assertEqual(len(rww), 1)
         self.assertDictEqual(rww[0].params, DEFAULT_PARAMS_REDUCED)
-        self.assertEqual(len(rww.default_network_coupling), 2)
+        self.assertEqual(len(rww.default_network_coupling), 1)
         np.testing.assert_equal(np.array(rww[0].initial_state), rww.initial_state)
 
     def test_run(self):
@@ -178,4 +177,5 @@ class TestReducedWongWangNetworkNode(unittest.TestCase):
             corr_mat = np.corrcoef(
                 np.vstack([result[state_var].values.flatten().astype(float) for result in all_results])
             )
+            print(corr_mat)
             self.assertTrue(np.greater(corr_mat, CORR_THRESHOLD).all())

--- a/tests/test_evolution.py
+++ b/tests/test_evolution.py
@@ -105,7 +105,7 @@ class TestALNEvolution(unittest.TestCase):
         evolution.dfEvolution
 
         # evolution information
-        evolution.info()
+        evolution.info(plot=False)
         dfPop = evolution.dfPop(outputs=True)
         self.assertEqual(len(dfPop), len(evolution.pop))
         evolution.dfEvolution()


### PR DESCRIPTION
The second PR of the MultiModel framework, now we know how the internals and model building works so this one should be quick -- introducing different models:
* FitzHugh-Nagumo
* thalamic mass model due to Costa et al.
* Wilson-Cowan
* Wong-Wang (both excitatory vs inhibitory version of `Node` - as Wilson-Cowan and Reduced version of `Node` with one mass - as FitzHugh-Nagumo)

(Side note - our holy grail - AdEx model - will follow in PR3 as it is more complicated to define since it involves table lookup and it's tricky to do that in symbolic derivatives).

All models are tested - whether they can be initialised, they are run with both backend and their output compared and moreover they are tested against `neurolib`'s native implementation (with exception of Wong-Wang since it's not in the `neurolib`)

WIP:
* [x] Wong-Wang testing against virtual brain implementation - they have reduced version
* [x] finish unit tests for Wong-Wang

I suggest you can start reviewing other models than Wong-Wang and in the meantime, I'll compare this implementation with TVB's
