### PR TITLE
Simplify `jitcdde` backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,7 @@ name: ci
 
 on:
   push:
-    branches:
-      - "*"
   pull_request:
-    branches:
-      - "*"
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install MacOS dependencies
-        if: startsWith(matrix.os, 'macos')
-        run: |
-          set -e
-          brew update
-          brew install llvm libomp
-          echo "/usr/local/opt/llvm/bin" >> $GITHUB_PATH
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Remove unused options for `jitcdde` backend:
* OpenMP support - `jitcdde` can use OpenMP for compiling symbolic equations into C. However, this comes with tremendous overhead and while I was testing this, OpenMP does not offer almost any speedup
* save / load compiled - there is an option to save compiled C code of the equations and then just load it on next run. In theory, this would significantly speed up computations of large networks where the compilation to C takes a lot of time. However, our code works in a way that parameter values are "hardcoded" into symbolic computation, hence on each parameter change (imagine exploration), we would need to compile again. And therefore I cannot see any use case of this as of now.