### PR TITLE
MultiModel evolution: allow "extra" keys

### DIFF
--- a/neurolib/models/multimodel/model.py
+++ b/neurolib/models/multimodel/model.py
@@ -69,7 +69,7 @@ class MultiModel(Model):
         # all matrices to floats
         for k, v in params.items():
             if isinstance(v, np.ndarray):
-                params[k] = v.astype(np.floating)
+                params[k] = v.astype(np.float)
         params.update(DEFAULT_RUN_PARAMS)
         params["name"] = self.model_instance.label
         params["description"] = self.model_instance.name

--- a/neurolib/utils/collections.py
+++ b/neurolib/utils/collections.py
@@ -135,17 +135,21 @@ def unwrap_star_dotdict(dct, model, replaced_dict=False):
     """
     Unwrap star notation of parameters into full list of parameeters for a given
     model.
-    E.g. params["*tau"] = 2.3 => params["mass1.tau"] = 2.3 and params["mass2.tau] = 2.3
+    E.g. params["*tau"] = 2.3 => params["mass1.tau"] = 2.3 and params["mass2.tau"] = 2.3
     """
-    # for each `k` that possibly contain stars get all key_u (unwrapped keys) from the star_dotdict
     return_dct = {}
     for k, v in dct.items():
         try:
-            for key_u in list(model.params[_sanitize_keys(k, replaced_dict)].keys()):
+            # for each `k` that possibly contain stars get all key_u (unwrapped keys) from the star_dotdict
+            star_keys = list(model.params[_sanitize_keys(k, replaced_dict)].keys())
+            for key_u in star_keys:
                 return_dct[key_u] = v
-        # if the key is not in the model params
+            # if there is a star in key but not in model params -> add it "raw"
+            if len(star_keys) == 0:
+                logging.info(f"Key `{k}` cannot be resolved.")
+                return_dct[k] = v
+        # if the non-star key is not in the model params it throws an AttributeError, but that's ok
         except AttributeError:
-            logging.warning(f"Key `{k}` not in model parameters")
             # add it "raw"
             return_dct[k] = v
     return return_dct

--- a/neurolib/utils/collections.py
+++ b/neurolib/utils/collections.py
@@ -146,13 +146,9 @@ def unwrap_star_dotdict(dct, model, replaced_dict=False):
         # if the key is not in the model params
         except AttributeError:
             logging.warning(f"Key `{k}` not in model parameters")
+            # add it "raw"
+            return_dct[k] = v
     return return_dct
-    # if replaced_dict:
-    #     return {
-    #         key_u: v for k, v in dct.items() for key_u in list(model.params[_sanitize_keys(k, replaced_dict)].keys())
-    #     }
-    # else:
-    #     return {key_u: v for k, v in dct.items() for key_u in list(model.params[k].keys())}
 
 
 def flatten_nested_dict(nested_dict, parent_key="", sep=DEFAULT_STAR_SEPARATOR):

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -109,6 +109,7 @@ class TestCollections(unittest.TestCase):
             "WCnode_0.WCmassEXC_0.noise_0.tau": 2.5,
             "WCnode_0.WCmassINH_1.tau": 2.5,
             "WCnode_0.WCmassINH_1.noise_0.tau": 2.5,
+            "key_not_there": 12.0,
         }
         root_logger = logging.getLogger()
         with self.assertLogs(root_logger, level="WARNING") as cm:

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -1,5 +1,8 @@
+import logging
 import unittest
 
+from neurolib.models.multimodel import MultiModel
+from neurolib.models.multimodel.builder.wilson_cowan import WilsonCowanNode
 from neurolib.utils.collections import (
     BACKWARD_REPLACE,
     FORWARD_REPLACE,
@@ -10,9 +13,6 @@ from neurolib.utils.collections import (
     star_dotdict,
     unwrap_star_dotdict,
 )
-
-from neurolib.models.multimodel.builder.wilson_cowan import WilsonCowanNode
-from neurolib.models.multimodel import MultiModel
 
 
 class TestCollections(unittest.TestCase):
@@ -101,6 +101,21 @@ class TestCollections(unittest.TestCase):
         }
         unwrapped = unwrap_star_dotdict(dct, wc, replaced_dict=BACKWARD_REPLACE)
         self.assertDictEqual(unwrapped, should_be)
+
+        # test exception with logging message
+        dct = {"STARtau": 2.5, "key_not_there": 12.0}
+        should_be = {
+            "WCnode_0.WCmassEXC_0.tau": 2.5,
+            "WCnode_0.WCmassEXC_0.noise_0.tau": 2.5,
+            "WCnode_0.WCmassINH_1.tau": 2.5,
+            "WCnode_0.WCmassINH_1.noise_0.tau": 2.5,
+        }
+        root_logger = logging.getLogger()
+        with self.assertLogs(root_logger, level="WARNING") as cm:
+            unwrapped = unwrap_star_dotdict(dct, wc, replaced_dict=BACKWARD_REPLACE)
+        self.assertDictEqual(unwrapped, should_be)
+        print(cm.output)
+        self.assertTrue("WARNING:root:Key `key_not_there` not in model parameters" in cm.output[0])
 
 
 if __name__ == "__main__":

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -103,20 +103,20 @@ class TestCollections(unittest.TestCase):
         self.assertDictEqual(unwrapped, should_be)
 
         # test exception with logging message
-        dct = {"STARtau": 2.5, "key_not_there": 12.0}
+        dct = {"STARtau": 2.5, "*key_not_there": 12.0}
         should_be = {
             "WCnode_0.WCmassEXC_0.tau": 2.5,
             "WCnode_0.WCmassEXC_0.noise_0.tau": 2.5,
             "WCnode_0.WCmassINH_1.tau": 2.5,
             "WCnode_0.WCmassINH_1.noise_0.tau": 2.5,
-            "key_not_there": 12.0,
+            "*key_not_there": 12.0,
         }
         root_logger = logging.getLogger()
-        with self.assertLogs(root_logger, level="WARNING") as cm:
+        with self.assertLogs(root_logger, level="INFO") as cm:
             unwrapped = unwrap_star_dotdict(dct, wc, replaced_dict=BACKWARD_REPLACE)
         self.assertDictEqual(unwrapped, should_be)
         print(cm.output)
-        self.assertTrue("WARNING:root:Key `key_not_there` not in model parameters" in cm.output[0])
+        self.assertTrue("INFO:root:Key `*key_not_there` cannot be resolved." in cm.output[0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Last step before ALN+thalamus motif evolution. 
The tricky part was to optimize with respect to connectivity. Because connectivity is a matrix, and AFAIK you cannot parameterize matrix within evolution framework in neurolib. So I used a "trick":
- I added parameters to `model.params` such as `model.params["aln_thal"]` and `model.params["thal_aln"]` for both connection strengths - now they are floats, so evaluation (`deap`) can work with them
- inside the `evaluateSimulation` function I created explicitly a connectivity matrix as `np.array([[0.0, model.params["thal_aln"]], [model.params["aln_thal"], 0.0]])`
- I assign this connectivity to the model

But it was not working. This is because of another MultiModel trait: usage of "star" notation. I was using `unwrap_star_dotdict` from `collections` to actually assign all parameters based on the star notation. This function was throwing an error when it found a key that is not an integral part of the model (so arbitrary parameter that is not needed for the model, such as the artificial connectivity floats). This PR fixes this: if it finds a key that is not part of the model, it just throws a warning but propagates that key forward, so you can explicitly build a connectivity matrix yourself.