### PR TITLE
MultiModel Chad-numba backend

### DIFF
--- a/neurolib/models/multimodel/builder/__init__.py
+++ b/neurolib/models/multimodel/builder/__init__.py
@@ -1,0 +1,8 @@
+from .aln import ALNNetwork, ALNNode
+from .base.network import Network, Node, SingleCouplingExcitatoryInhibitoryNode
+from .base.neural_mass import NeuralMass
+from .fitzhugh_nagumo import FitzHughNagumoNetwork, FitzHughNagumoNode
+from .hopf import HopfNetwork, HopfNode
+from .thalamus import ThalamicNode
+from .wilson_cowan import WilsonCowanNetwork, WilsonCowanNode
+from .wong_wang import ReducedWongWangNetwork, ReducedWongWangNode, WongWangNetwork, WongWangNode

--- a/neurolib/models/multimodel/builder/aln.py
+++ b/neurolib/models/multimodel/builder/aln.py
@@ -814,13 +814,13 @@ class ALNNode(SingleCouplingExcitatoryInhibitoryNode):
         )
         self._rescale_connectivity()
 
-    def update_params(self, params_dict):
+    def update_params(self, params_dict, rescale=True):
         """
         Rescale connectivity after params update if connectivity was updated.
         """
         rescale_flag = "local_connectivity" in params_dict
         super().update_params(params_dict)
-        if rescale_flag:
+        if rescale_flag and rescale:
             self._rescale_connectivity()
 
     def _sync(self):

--- a/neurolib/models/multimodel/builder/base/backend.py
+++ b/neurolib/models/multimodel/builder/base/backend.py
@@ -207,8 +207,11 @@ def integrate(dt, n, max_delay, t_max, y0, input_y):
         logging.info("Compiling python code using numba's njit...")
         numba_func = self.NUMBA_EULER_TEMPLATE.format(dy_eqs=derivatives_str)
         # compile numba function and load into namespace
+        print(numba_func)
         numba_code = compile(numba_func, "<string>", "exec")
-        integrate = numba.njit(
+        integrate = numba.jit(
+            "float64[:,:](float64,int32,int32,int32,float64[:,:],float64[:,:])", nopython=True, fastmath=True
+        )(
             FunctionType(
                 numba_code.co_consts[-3],
                 {

--- a/neurolib/models/multimodel/builder/base/backend.py
+++ b/neurolib/models/multimodel/builder/base/backend.py
@@ -152,20 +152,23 @@ def integrate(dt, n, max_delay, t_max, y0, input_y):
         dot as a separator. Does not translate noise parameters.
 
         :param param_dict: dictionary with parameters and their values
-        :typoe param_dict: dict
+        :type param_dict: dict
+        :return: dictionary with parameters and symbols
+        :rtype: dict
         """
-        param_dict = deepcopy(param_dict)
+        # param_dict = deepcopy(param_dict)
+        symbol_dict = {}
         for k, v in param_dict.items():
             splitted_key = k.split(".")
             if any("noise" in sp for sp in splitted_key):
                 continue
             if isinstance(v, (float, int)):
-                param_dict[k] = sp.Symbol(k.replace(".", "DOT"))
+                symbol_dict[k] = sp.Symbol(k.replace(".", "DOT"))
             elif isinstance(v, np.ndarray):
-                param_dict[k] = sp.MatrixSymbol(k.replace(".", "DOT"), *v.shape)
+                symbol_dict[k] = sp.MatrixSymbol(k.replace(".", "DOT"), *v.shape)
             else:
                 raise ValueError(f"Cannot handle {type(v)} type of {k}")
-        return param_dict
+        return symbol_dict
 
     def _replace_current_ys(self, expression):
         """

--- a/neurolib/models/multimodel/builder/base/backend.py
+++ b/neurolib/models/multimodel/builder/base/backend.py
@@ -104,6 +104,8 @@ class BaseBackend:
     state_variable_names = None
     label = None
 
+    backend_name = ""
+
     def run(self):
         raise NotImplementedError
 
@@ -116,6 +118,8 @@ class NumbaBackend(BaseBackend):
     Numba integration backend using Euler scheme with delays. The symbolic code for
     derivatives is rendered into a prepared string template using numba's njit.
     """
+
+    backend_name = "numba"
 
     DEFAULT_DT = 0.1  # in ms
 
@@ -343,6 +347,7 @@ class JitcddeBackend(BaseBackend):
         Numerical Mathematics, 37(4), 441-458.
     """
 
+    backend_name = "jitcdde"
     extra_compile_args = []
     dde_system = None
 
@@ -528,7 +533,7 @@ class BackendIntegrator:
         assert self.initialised, "Model must be initialised"
         assert isinstance(noise_input, (CubicHermiteSpline, np.ndarray))
 
-        if self.backend_instance is None:
+        if (self.backend_instance is None) or (self.backend_instance.backend_name != backend):
             logging.info(f"Initialising {backend} backend...")
             self._init_backend(backend)
         assert isinstance(self.backend_instance, BaseBackend)

--- a/neurolib/models/multimodel/builder/base/network.py
+++ b/neurolib/models/multimodel/builder/base/network.py
@@ -3,6 +3,7 @@ from itertools import chain, islice
 
 import numpy as np
 import symengine as se
+import sympy as sp
 from jitcdde import t as time_vector
 from jitcdde import y as state_vector
 
@@ -404,10 +405,10 @@ class SingleCouplingExcitatoryInhibitoryNode(Node):
         params_dict = self._sanitize_update_params(params_dict)
         local_connectivity = params_dict.pop(NODE_CONNECTIVITY, None)
         local_delays = params_dict.pop(NODE_DELAYS, None)
-        if local_connectivity is not None and isinstance(local_connectivity, np.ndarray):
+        if local_connectivity is not None and isinstance(local_connectivity, (np.ndarray, sp.MatrixSymbol)):
             assert local_connectivity.shape == self.connectivity.shape
             self.connectivity = local_connectivity.astype(np.floating)
-        if local_delays is not None and isinstance(local_delays, np.ndarray):
+        if local_delays is not None and isinstance(local_delays, (np.ndarray, sp.MatrixSymbol)):
             assert local_delays.shape == self.delays.shape
             self.delays = local_delays.astype(np.floating)
         super().update_params(params_dict)

--- a/neurolib/models/multimodel/builder/base/neural_mass.py
+++ b/neurolib/models/multimodel/builder/base/neural_mass.py
@@ -178,7 +178,7 @@ class NeuralMass:
         for i, noise_process in enumerate(self.noise_input):
             self.params[f"noise_{i}"] = noise_process.get_params()
 
-    def update_params(self, params_dict):
+    def update_params(self, params_dict, **kwargs):
         """
         Update parameters of the mass.
 

--- a/neurolib/models/multimodel/builder/base/params.py
+++ b/neurolib/models/multimodel/builder/base/params.py
@@ -1,0 +1,73 @@
+"""
+Set of convenience functions for parameter handling in MultiModel.
+"""
+
+import numpy as np
+import sympy as sp
+from sympy.core import symbol
+
+
+def count_float_params(param_dict):
+    """
+    Count number of float parameters in a dictionary, do not count noise
+    parameters.
+    """
+    return len(
+        {
+            k: v
+            for k, v in param_dict.items()
+            if isinstance(v, (int, float))
+            if not any(["noise" in sp for sp in k.split(".")])
+        }
+    )
+
+
+def float_params_to_vector_symbolic(param_dict):
+    """
+    Transforms float / array / int parameters to symbolic ones. Assumes flat
+    dictionary with dot as a separator. Does not translate noise parameters.
+
+    :param param_dict: dictionary with parameters and their values
+    :type param_dict: dict
+    :return: dictionary with parameters and symbols
+    :rtype: dict
+    """
+    param_vec = sp.MatrixSymbol("param", n=count_float_params(param_dict), m=1)
+
+    cnt = 0
+    symbol_dict = {}
+    for k, v in param_dict.items():
+        splitted_key = k.split(".")
+        if any(["noise" in sp for sp in splitted_key]):
+            continue
+        if isinstance(v, (float, int)):
+            symbol_dict[k] = param_vec[cnt, 0]
+            cnt += 1
+        elif isinstance(v, np.ndarray):
+            symbol_dict[k] = sp.MatrixSymbol(k.replace(".", "DOT"), *v.shape)
+        else:
+            raise ValueError(f"Cannot handle {type(v)} type of {k}")
+    return symbol_dict
+
+
+def float_params_to_individual_symbolic(param_dict):
+    """
+    Transforms float / array / int parameters to symbolic ones. Assumes flat
+    dictionary with dot as a separator. Does not translate noise parameters. All
+    parameters are Symbols, compatible with symengine.
+    """
+    symbol_dict = {}
+    for k, v in param_dict.items():
+        splitted_key = k.split(".")
+        if any(["noise" in sp for sp in splitted_key]):
+            continue
+        if isinstance(v, (float, int)):
+            symbol_dict[k] = sp.Symbol(k.replace(".", "DOT"))
+        elif isinstance(v, np.ndarray):
+            symbol_base_str = k.replace(".", "DOT")
+            symbol_dict[k] = np.array(
+                [sp.Symbol(f"{symbol_base_str}_{i}_{j}") for i in range(v.shape[0]) for j in range(v.shape[1])]
+            ).reshape(v.shape)
+        else:
+            raise ValueError(f"Cannot handle {type(v)} type of {k}")
+    return symbol_dict

--- a/tests/multimodel/base/test_backend.py
+++ b/tests/multimodel/base/test_backend.py
@@ -51,6 +51,7 @@ class TestBaseBackend(unittest.TestCase):
         base = BaseBackend()
         self.assertTrue(isinstance(base, BaseBackend))
         self.assertTrue(hasattr(base, "run"))
+        self.assertTrue(hasattr(base, "backend_name"))
         self.assertTrue(hasattr(base, "clean"))
         self.assertEqual(base._derivatives, None)
         self.assertEqual(base._sync, None)
@@ -70,6 +71,7 @@ class TestBaseBackend(unittest.TestCase):
 class TestJitcddeBackend(unittest.TestCase):
     def test_init(self):
         backend = JitcddeBackend()
+        self.assertEqual(backend.backend_name, "jitcdde")
         self.assertTrue(isinstance(backend, JitcddeBackend))
         self.assertTrue(isinstance(backend, BaseBackend))
         self.assertTrue(hasattr(backend, "_init_and_compile_C"))
@@ -82,6 +84,7 @@ class TestJitcddeBackend(unittest.TestCase):
 class TestNumbaBackend(unittest.TestCase):
     def test_init(self):
         backend = NumbaBackend()
+        self.assertEqual(backend.backend_name, "numba")
         self.assertTrue(isinstance(backend, NumbaBackend))
         self.assertTrue(isinstance(backend, BaseBackend))
         self.assertTrue(hasattr(backend, "_replace_current_ys"))

--- a/tests/multimodel/base/test_backend.py
+++ b/tests/multimodel/base/test_backend.py
@@ -11,6 +11,7 @@ import numba
 import numpy as np
 import pytest
 import symengine as se
+import sympy as sp
 import xarray as xr
 from jitcdde import t as time_vector
 from jitcdde import y as state_vector
@@ -87,6 +88,15 @@ class TestNumbaBackend(unittest.TestCase):
         self.assertTrue(hasattr(backend, "_replace_past_ys"))
         self.assertTrue(hasattr(backend, "_replace_inputs"))
         self.assertTrue(hasattr(backend, "_substitute_helpers"))
+
+    def float_parameters_to_symbolic(self):
+        backend = NumbaBackend()
+        DICT_IN = {"a": 40.0, "b": 15, "conn": np.random.rand(4, 4)}
+        result = backend.float_parameters_to_symbolic(DICT_IN)
+        for k, v in result.items():
+            self.assertTrue(isinstance(v, (sp.Symbol, sp.MatrixSymbol)))
+            if isinstance(v, sp.MatrixSymbol):
+                self.assertTupleEqual(v.shape, DICT_IN[k].shape)
 
     def test_replace_current_ys(self):
         backend = NumbaBackend()

--- a/tests/multimodel/base/test_backend.py
+++ b/tests/multimodel/base/test_backend.py
@@ -89,7 +89,7 @@ class TestNumbaBackend(unittest.TestCase):
         self.assertTrue(hasattr(backend, "_replace_inputs"))
         self.assertTrue(hasattr(backend, "_substitute_helpers"))
 
-    def float_parameters_to_symbolic(self):
+    def test_float_parameters_to_symbolic(self):
         backend = NumbaBackend()
         DICT_IN = {"a": 40.0, "b": 15, "conn": np.random.rand(4, 4)}
         result = backend.float_parameters_to_symbolic(DICT_IN)

--- a/tests/multimodel/base/test_backend.py
+++ b/tests/multimodel/base/test_backend.py
@@ -92,15 +92,6 @@ class TestNumbaBackend(unittest.TestCase):
         self.assertTrue(hasattr(backend, "_replace_inputs"))
         self.assertTrue(hasattr(backend, "_substitute_helpers"))
 
-    def test_float_parameters_to_symbolic(self):
-        backend = NumbaBackend()
-        DICT_IN = {"a": 40.0, "b": 15, "conn": np.random.rand(4, 4)}
-        result = backend.float_parameters_to_symbolic(DICT_IN)
-        for k, v in result.items():
-            self.assertTrue(isinstance(v, (sp.Symbol, sp.MatrixSymbol)))
-            if isinstance(v, sp.MatrixSymbol):
-                self.assertTupleEqual(v.shape, DICT_IN[k].shape)
-
     def test_replace_current_ys(self):
         backend = NumbaBackend()
         STRING_IN = "0.4*(1.0*(1.0 - current_y(0))"

--- a/tests/multimodel/base/test_backend.py
+++ b/tests/multimodel/base/test_backend.py
@@ -14,9 +14,35 @@ import symengine as se
 import xarray as xr
 from jitcdde import t as time_vector
 from jitcdde import y as state_vector
-from neurolib.models.multimodel.builder.base.backend import BackendIntegrator, BaseBackend, JitcddeBackend, NumbaBackend
+from neurolib.models.multimodel.builder.base.backend import (
+    BackendIntegrator,
+    BaseBackend,
+    JitcddeBackend,
+    NumbaBackend,
+    NumbaFunctionCache,
+)
 from neurolib.utils.saver import save_to_netcdf, save_to_pickle
 from neurolib.utils.stimulus import ZeroInput
+
+
+class TestNumbaFunctionCache(unittest.TestCase):
+
+    cache = NumbaFunctionCache()
+
+    @staticmethod
+    def foo(a, b):
+        return a + b
+
+    def test_hashing(self):
+        self.cache.hash = (1, 2, 3, 4)
+        self.assertEqual(self.cache.hash, hash((1, 2, 3, 4)))
+        self.assertTrue(self.cache((1, 2, 3, 4)))
+        self.assertFalse(self.cache((1, 2, 3)))
+
+    def test_caching(self):
+        self.assertTrue(self.cache.cache is None)
+        self.cache.cache = self.foo
+        self.assertEqual(self.cache.cache.__code__.co_code, self.foo.__code__.co_code)
 
 
 class TestBaseBackend(unittest.TestCase):

--- a/tests/multimodel/base/test_backend.py
+++ b/tests/multimodel/base/test_backend.py
@@ -106,9 +106,9 @@ class TestNumbaBackend(unittest.TestCase):
             "node1.mass1.noise.a": sp.Symbol("noise_a"),
             "node1.connectivity": np.array([[sp.Symbol("conn11"), sp.Symbol("conn12")]]),
         }
-        should_be = [sp.Symbol("a"), sp.Symbol("conn11"), sp.Symbol("conn12")]
+        should_be = set([sp.Symbol("conn11"), sp.Symbol("conn12"), sp.Symbol("a")])
         result = backend._get_numba_function_params(symbol_params)
-        self.assertListEqual(result, should_be)
+        self.assertSetEqual(set(result), should_be)
 
     def test_create_symbol_to_float_dict(self):
         backend = NumbaBackend()
@@ -210,7 +210,8 @@ class TestBackendIntegrator(unittest.TestCase):
     def test_init_system(self):
         system = BackendTestingHelper()
         self.assertTrue(hasattr(system, "_init_xarray"))
-        self.assertTrue(hasattr(system, "_init_backend"))
+        self.assertTrue(hasattr(system, "_init_jitcdde_backend"))
+        self.assertTrue(hasattr(system, "_init_numba_backend"))
         self.assertTrue(hasattr(system, "run"))
 
     def test_run_jitcdde(self):

--- a/tests/multimodel/base/test_params.py
+++ b/tests/multimodel/base/test_params.py
@@ -1,0 +1,45 @@
+"""
+Simple test for parameters.
+"""
+
+import unittest
+
+import numpy as np
+import sympy as sp
+from neurolib.models.multimodel.builder.base.params import (
+    count_float_params,
+    float_params_to_individual_symbolic,
+    float_params_to_vector_symbolic,
+)
+
+
+class TestSymbolicParams(unittest.TestCase):
+    def test_count_float_params(self):
+        DICT_IN = {"a": 40.0, "b": 15, "conn": np.random.rand(4, 4), "a.noise": 12.5}
+        length = count_float_params(DICT_IN)
+        self.assertEqual(length, 2)
+
+    def test_float_params_to_vector_symbolic(self):
+        DICT_IN = {"a": 40.0, "b": 15, "conn": np.random.rand(4, 4)}
+        result = float_params_to_vector_symbolic(DICT_IN)
+        self.assertEqual(len(result), len(DICT_IN))
+        self.assertEqual(result.keys(), DICT_IN.keys())
+        for k, v in result.items():
+            self.assertTrue(isinstance(v, (sp.matrices.expressions.matexpr.MatrixElement, sp.MatrixSymbol)))
+            if isinstance(v, sp.MatrixSymbol):
+                self.assertTupleEqual(v.shape, DICT_IN[k].shape)
+
+    def test_float_params_to_individual_symbolic(self):
+        DICT_IN = {"a": 40.0, "b": 15, "conn": np.random.rand(4, 4)}
+        result = float_params_to_individual_symbolic(DICT_IN)
+        self.assertEqual(len(result), len(DICT_IN))
+        self.assertEqual(result.keys(), DICT_IN.keys())
+        for k, v in result.items():
+            self.assertTrue(isinstance(v, (sp.Symbol, np.ndarray)))
+            if isinstance(v, np.ndarray):
+                self.assertTupleEqual(v.shape, DICT_IN[k].shape)
+                self.assertTrue(all([isinstance(element, sp.Symbol) for element in v.flatten()]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/multimodel/test_aln.py
+++ b/tests/multimodel/test_aln.py
@@ -174,14 +174,6 @@ class TestALNMass(ALNMassTestCase):
             self.assertEqual(len(aln.initial_state), aln.num_state_variables)
             self.assertEqual(len(aln.noise_input_idx), aln.num_noise_variables)
 
-    def test_update_rescale_params(self):
-        # update params that have to do something with rescaling
-        UPDATE_PARAMS = {"C": 150.0, "Jee_max": 3.0}
-        aln = self._create_exc_mass()
-        aln.update_params(UPDATE_PARAMS)
-        self.assertEqual(aln.params["taum"], 15.0)
-        self.assertEqual(aln.params["c_gl"], 0.4 * aln.params["tau_se"] / 3.0)
-
     def test_run(self):
         aln_exc = self._create_exc_mass()
         aln_inh = self._create_inh_mass()

--- a/tests/multimodel/test_aln.py
+++ b/tests/multimodel/test_aln.py
@@ -286,7 +286,7 @@ class TestALNNetwork(unittest.TestCase):
             if np.isnan(all_ts).any():
                 continue
             corr_mat = np.corrcoef(all_ts)
-            print(corr_mat)
+            print(state_var, corr_mat, np.var(all_ts))
             self.assertTrue(np.greater(corr_mat, CORR_THRESHOLD).all())
 
     @pytest.mark.xfail


### PR DESCRIPTION
A newer and shiny `numba` backend to MultiModel.
Before: 
- each new model parameters meant a new compilation since model parameters were directly inserted as floats into symbolic equations

Now:
- when using `numba` backend, all parameters are transformed to `sp.Symbol`, used function arguments for `numba`-jitted `integrate` function
- therefore when parameters change, no new compilation is needed

Apart from the new `numba` backend, I had to make some small changes to the existing code. In order to make this easier for you, I'll comment directly into the code below.
