### PR TITLE
MultiModel continue run

### DIFF
--- a/neurolib/models/multimodel/builder/base/backend.py
+++ b/neurolib/models/multimodel/builder/base/backend.py
@@ -394,7 +394,7 @@ class JitcddeBackend(BaseBackend):
             verbose=False,
         )
 
-    def _set_constant_past(self, past_state):
+    def _set_constant_past(self, past_state, squeeze=False):
         """
         Sets past of the delayed system with a constant vector. This usually
         means that `past_state` is 1D vector of length `num_state_variables`.
@@ -404,7 +404,10 @@ class JitcddeBackend(BaseBackend):
         :param past_state: vector of past states of length `num_state_variables`
         :type past_state: np.ndarray
         """
-        self.dde_system.constant_past(past_state)
+        if squeeze:
+            self.dde_system.constant_past(past_state.squeeze())
+        else:
+            self.dde_system.constant_past(past_state)
         self.dde_system.adjust_diff()
 
     def _set_past_from_vector(self, past_state, dt):
@@ -423,7 +426,6 @@ class JitcddeBackend(BaseBackend):
         """
         derivatives = np.hstack([np.zeros((past_state.shape[0], 1)), np.diff(past_state, axis=1)])
         assert derivatives.shape == past_state.shape
-        print(past_state.shape)
         for t in range(past_state.shape[1]):
             self.dde_system.add_past_point(-t * dt, past_state[:, -t], derivatives[:, -t])
         self.dde_system.adjust_diff()
@@ -466,8 +468,10 @@ class JitcddeBackend(BaseBackend):
         self.dde_system.purge_past()
         self.dde_system.reset_integrator()
         logging.info("Setting past of the state vector...")
-        if self.initial_state.squeeze().ndim == 1:
-            self._set_constant_past(self.initial_state.squeeze())
+        if self.initial_state.ndim == 1:
+            self._set_constant_past(self.initial_state)
+        elif self.initial_state.shape[1] == 1:
+            self._set_constant_past(self.initial_state, squeeze=True)
         else:
             self._set_past_from_vector(self.initial_state, dt)
         # integrate
@@ -550,7 +554,27 @@ class BackendIntegrator:
         assert self.initialised, "Model must be initialised"
         assert isinstance(noise_input, (CubicHermiteSpline, np.ndarray))
 
-        if (self.backend_instance is None) or (self.backend_instance.backend_name != backend):
+        def _check_backend_init():
+            # if backend was never initialized -> init and compile
+            if self.backend_instance is None:
+                return True
+            # if user wants different backend -> init other backend
+            if self.backend_instance.backend_name != backend:
+                return True
+            # if symbol_params exists (i.e. we used numba backend before)
+            if self.symbol_params is not None:
+                # set on dict gets the set of dict's keys
+                existing_params = set(flatten_nested_dict(self.symbol_params))
+                new_params = set(flatten_nested_dict(self.get_nested_params()))
+                # if the keys differ (i.e. parameter keys changed) -> recompile
+                # set - set produces an intersection and if empty, then bool(<empty set>) = False
+                # if not empty then bool(<set>) = True
+                if bool(existing_params - new_params):
+                    return True
+
+            return False
+
+        if _check_backend_init():
             logging.info(f"Initialising {backend} backend...")
             if backend == "jitcdde":
                 self._init_jitcdde_backend()

--- a/neurolib/models/multimodel/builder/base/backend.py
+++ b/neurolib/models/multimodel/builder/base/backend.py
@@ -423,6 +423,7 @@ class JitcddeBackend(BaseBackend):
         """
         derivatives = np.hstack([np.zeros((past_state.shape[0], 1)), np.diff(past_state, axis=1)])
         assert derivatives.shape == past_state.shape
+        print(past_state.shape)
         for t in range(past_state.shape[1]):
             self.dde_system.add_past_point(-t * dt, past_state[:, -t], derivatives[:, -t])
         self.dde_system.adjust_diff()
@@ -465,8 +466,8 @@ class JitcddeBackend(BaseBackend):
         self.dde_system.purge_past()
         self.dde_system.reset_integrator()
         logging.info("Setting past of the state vector...")
-        if self.initial_state.ndim == 1:
-            self._set_constant_past(self.initial_state)
+        if self.initial_state.squeeze().ndim == 1:
+            self._set_constant_past(self.initial_state.squeeze())
         else:
             self._set_past_from_vector(self.initial_state, dt)
         # integrate
@@ -561,6 +562,9 @@ class BackendIntegrator:
         if isinstance(self.backend_instance, NumbaBackend):
             assert self.are_params_floats
             self.float_params = deepcopy(self.get_nested_params())
+
+        # update initial state
+        self.backend_instance.initial_state = self.initial_state.copy()
         times, result = self.backend_instance.run(
             duration=duration,
             dt=dt,

--- a/neurolib/models/multimodel/model.py
+++ b/neurolib/models/multimodel/model.py
@@ -94,6 +94,14 @@ class MultiModel(Model):
         self.model_instance.update_params(flat_dict_to_nested(params_to_update))
 
     @property
+    def num_noise_variables(self):
+        return self.model_instance.num_noise_variables
+
+    @property
+    def num_state_variables(self):
+        return self.model_instance.num_state_variables
+
+    @property
     def noise_input(self):
         return self.model_instance.noise_input
 

--- a/neurolib/models/multimodel/model.py
+++ b/neurolib/models/multimodel/model.py
@@ -93,6 +93,17 @@ class MultiModel(Model):
         params_to_update = {k: v for k, v in self.params.items() if self.model_instance.label in k}
         self.model_instance.update_params(flat_dict_to_nested(params_to_update))
 
+    @property
+    def noise_input(self):
+        return self.model_instance.noise_input
+
+    @noise_input.setter
+    def noise_input(self, new_noise):
+        self.model_instance.noise_input = new_noise
+        # re-set the model params
+        new_model_params = flatten_nested_dict(self.model_instance.get_nested_params())
+        self.params.update(new_model_params)
+
     def run(
         self,
         chunkwise=False,

--- a/neurolib/models/multimodel/model.py
+++ b/neurolib/models/multimodel/model.py
@@ -214,6 +214,12 @@ class MultiModel(Model):
         # set initial state
         self.model_instance.initial_state = new_initial_state
 
+    def clearModelState(self):
+        # set start_t to zero again
+        self.start_t = 0.0
+        # `clearModelState` as per base class
+        super().clearModelState()
+
     def integrateChunkwise(self, chunksize, bold, append_outputs):
         raise NotImplementedError("for now...")
 

--- a/tests/multimodel/base/test_backend.py
+++ b/tests/multimodel/base/test_backend.py
@@ -8,7 +8,6 @@ import unittest
 from copy import deepcopy
 from shutil import rmtree
 
-import numba
 import numpy as np
 import pytest
 import symengine as se
@@ -308,6 +307,23 @@ class TestBackendIntegrator(unittest.TestCase):
         )
         self.assertTrue(all(dim in results.dims for dim in ["time", "node"]))
         self.assertDictEqual(results.attrs, self.EXTRA_ATTRS)
+
+    def test_run_both(self):
+        system = BackendTestingHelper()
+        results_numba = system.run(
+            self.DURATION,
+            self.DT,
+            ZeroInput().as_array(self.DURATION, self.DT),
+            backend="numba",
+        )
+        results_jitcdde = system.run(
+            self.DURATION,
+            self.DT,
+            ZeroInput().as_cubic_splines(self.DURATION, self.DT),
+            backend="jitcdde",
+        )
+        self.assertTrue(isinstance(results_jitcdde, xr.Dataset))
+        self.assertTrue(isinstance(results_numba, xr.Dataset))
 
     def test_save_pickle(self):
         """

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -225,6 +225,8 @@ class TestMultiModel(unittest.TestCase):
         self.assertTrue(isinstance(model.params, star_dotdict))
         self.assertTrue(model.integration is None)
         self.assertEqual(model.start_t, 0.0)
+        self.assertEqual(model.num_noise_variables, 4)
+        self.assertEqual(model.num_state_variables, 4)
         max_delay = int(DELAY / model.params["dt"])
         self.assertEqual(model.getMaxDelay(), max_delay)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -16,6 +16,7 @@ from neurolib.models.wc import WCModel
 from neurolib.models.ww import WWModel
 from neurolib.utils.collections import star_dotdict
 from neurolib.utils.loadData import Dataset
+from neurolib.utils.stimulus import ZeroInput
 
 
 class TestAln(unittest.TestCase):
@@ -223,8 +224,17 @@ class TestMultiModel(unittest.TestCase):
         self.assertEqual(model.model_instance, fhn_net)
         self.assertTrue(isinstance(model.params, star_dotdict))
         self.assertTrue(model.integration is None)
+        self.assertEqual(model.start_t, 0.0)
         max_delay = int(DELAY / model.params["dt"])
         self.assertEqual(model.getMaxDelay(), max_delay)
+
+    def test_noise_input(self):
+        DELAY = 13.0
+        fhn_net = FitzHughNagumoNetwork(np.random.rand(2, 2), np.array([[0.0, DELAY], [DELAY, 0.0]]))
+        model = MultiModel(fhn_net)
+        self.assertListEqual(model.noise_input, model.model_instance.noise_input)
+        model.noise_input = [ZeroInput()] * model.model_instance.num_noise_variables
+        self.assertListEqual(model.noise_input, model.model_instance.noise_input)
 
     def test_run_numba_w_bold(self):
         DELAY = 13.0
@@ -288,6 +298,45 @@ class TestMultiModel(unittest.TestCase):
         )
         for out_var in model.output_vars:
             np.testing.assert_equal(model[out_var], inst_res[out_var].values.T)
+
+    def test_continue_run_node(self):
+        fhn_node = FitzHughNagumoNode()
+        model = MultiModel.init_node(fhn_node)
+        model.params["sampling_dt"] = 10.0
+        model.params["backend"] = "numba"
+        # run MultiModel with continuation
+        model.run(continue_run=True)
+        last_t = model.t[-1]
+        last_x = model.state["x"][:, -model.maxDelay - 1 :]
+        last_y = model.state["y"][:, -model.maxDelay - 1 :]
+        # assert last state is initial state now
+        np.testing.assert_equal(last_x.squeeze(), model.model_instance.initial_state[0, :])
+        np.testing.assert_equal(last_y.squeeze(), model.model_instance.initial_state[1, :])
+        # change noise - just to make things more interesting
+        model.noise_input = [ZeroInput()] * model.model_instance.num_noise_variables
+        model.run()
+        # assert continuous time
+        self.assertAlmostEqual(model.t[0] - last_t, model.params["dt"] / 1000.0)
+
+    def test_continue_run_network(self):
+        DELAY = 13.0
+        fhn_net = FitzHughNagumoNetwork(np.random.rand(2, 2), np.array([[0.0, DELAY], [DELAY, 0.0]]))
+        model = MultiModel(fhn_net)
+        model.params["sampling_dt"] = 10.0
+        model.params["backend"] = "numba"
+        # run MultiModel with continuation
+        model.run(continue_run=True)
+        last_t = model.t[-1]
+        last_x = model.state["x"][:, -model.maxDelay - 1 :]
+        last_y = model.state["y"][:, -model.maxDelay - 1 :]
+        # assert last state is initial state now
+        np.testing.assert_equal(last_x, model.model_instance.initial_state[[0, 2], :])
+        np.testing.assert_equal(last_y, model.model_instance.initial_state[[1, 3], :])
+        # change noise - just to make things more interesting
+        model.noise_input = [ZeroInput()] * model.model_instance.num_noise_variables
+        model.run()
+        # assert continuous time
+        self.assertAlmostEqual(model.t[0] - last_t, model.params["dt"] / 1000.0)
 
 
 if __name__ == "__main__":

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -312,13 +312,17 @@ class TestMultiModel(unittest.TestCase):
         last_x = model.state["x"][:, -model.maxDelay - 1 :]
         last_y = model.state["y"][:, -model.maxDelay - 1 :]
         # assert last state is initial state now
+        self.assertEqual(model.start_t, last_t)
         np.testing.assert_equal(last_x.squeeze(), model.model_instance.initial_state[0, :])
         np.testing.assert_equal(last_y.squeeze(), model.model_instance.initial_state[1, :])
         # change noise - just to make things more interesting
         model.noise_input = [ZeroInput()] * model.model_instance.num_noise_variables
-        model.run()
+        model.run(continue_run=True)
         # assert continuous time
         self.assertAlmostEqual(model.t[0] - last_t, model.params["dt"] / 1000.0)
+        # assert start_t is reset to 0, when continue_run=False
+        model.run()
+        self.assertEqual(model.start_t, 0.0)
 
     def test_continue_run_network(self):
         DELAY = 13.0
@@ -332,13 +336,17 @@ class TestMultiModel(unittest.TestCase):
         last_x = model.state["x"][:, -model.maxDelay - 1 :]
         last_y = model.state["y"][:, -model.maxDelay - 1 :]
         # assert last state is initial state now
+        self.assertEqual(model.start_t, last_t)
         np.testing.assert_equal(last_x, model.model_instance.initial_state[[0, 2], :])
         np.testing.assert_equal(last_y, model.model_instance.initial_state[[1, 3], :])
         # change noise - just to make things more interesting
         model.noise_input = [ZeroInput()] * model.model_instance.num_noise_variables
-        model.run()
+        model.run(continue_run=True)
         # assert continuous time
         self.assertAlmostEqual(model.t[0] - last_t, model.params["dt"] / 1000.0)
+        # assert start_t is reset to 0, when continue_run=False
+        model.run()
+        self.assertEqual(model.start_t, 0.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`MultiModel` now able to accommodate continuous runs with `model.run(continue_run=True)`. It'll set initial state from previous run(s).
Naturally, one can change parameters between runs, and, moreover, one can also change (noise) inputs in between runs. 
E.g. one can start the ALN model with no noise for 2 seconds, then continue with Ornstein-Uhlenbeck and finally end it with sinusoidal input. Of course, one can change parameters in between.

Moreover, one last addition: some shortcuts for ease of access:
`model.num_state_variables` - return total number of state variables in the `MultiModel`
`model.num_noise_variables` - return the total number of variables that accept noise (e.g. in ALN node it's 2)
`model.noise_input` - return or set the full input to the model (list of length `num_noise_variables`)

Therefore, changing (noise) inputs for `MultiModel` was never easier:
```python
mm = MultiModel(...)
# list of `Input` classes of the same length as original list, i.e. mm.num_noise_variables
mm.noise_input = [stim.ZeroInput(), stim.OrnsteinUhlenback(...), ...]
# set all to the same input
mm.noise_input = [stim.ZeroInput()] * mm.num_noise_variables
# or change just one
mm.noise_input[1] = stim.ZeroInput()
```