### PR TITLE
QFix: Rescaling connectivity in ALN MultiModel

### DIFF
--- a/neurolib/models/multimodel/builder/aln.py
+++ b/neurolib/models/multimodel/builder/aln.py
@@ -818,8 +818,10 @@ class ALNNode(SingleCouplingExcitatoryInhibitoryNode):
         """
         Rescale connectivity after params update if connectivity was updated.
         """
-        rescale_flag = "local_connectivity" in params_dict
+        old_connectivity = self.connectivity.copy()
         super().update_params(params_dict)
+        # rescale when connectivity matrix is different
+        rescale_flag = not (self.connectivity == old_connectivity).all()
         if rescale_flag and rescale:
             self._rescale_connectivity()
 

--- a/neurolib/models/multimodel/model.py
+++ b/neurolib/models/multimodel/model.py
@@ -116,8 +116,11 @@ class MultiModel(Model):
 
     @noise_input.setter
     def noise_input(self, new_noise):
+        # first - update model params to save any changes
+        self._update_model_params()
+        # change the noise in the model instance
         self.model_instance.noise_input = new_noise
-        # re-set the model params
+        # re-set the model params - to write new noise params into self.params
         self._sync_model_params()
 
     def run(

--- a/neurolib/models/multimodel/model.py
+++ b/neurolib/models/multimodel/model.py
@@ -83,6 +83,13 @@ class MultiModel(Model):
             )
         return params
 
+    def _sync_model_params(self):
+        """
+        Pulls params from `model_instance` and updates self.params.
+        """
+        new_model_params = flatten_nested_dict(self.model_instance.get_nested_params())
+        self.params.update(new_model_params)
+
     def getMaxDelay(self):
         """
         Return max delay in units of dt. In ms, this is given as a property in the model instance.
@@ -92,6 +99,8 @@ class MultiModel(Model):
     def _update_model_params(self):
         params_to_update = {k: v for k, v in self.params.items() if self.model_instance.label in k}
         self.model_instance.update_params(flat_dict_to_nested(params_to_update))
+        # re-set the model params
+        self._sync_model_params()
 
     @property
     def num_noise_variables(self):
@@ -109,8 +118,7 @@ class MultiModel(Model):
     def noise_input(self, new_noise):
         self.model_instance.noise_input = new_noise
         # re-set the model params
-        new_model_params = flatten_nested_dict(self.model_instance.get_nested_params())
-        self.params.update(new_model_params)
+        self._sync_model_params()
 
     def run(
         self,


### PR DESCRIPTION
quick fix in rescaling connectivity on parameter update in MultiModel's ALN