### PR TITLE
More explore options

### DIFF
--- a/neurolib/optimize/exploration/exploration.py
+++ b/neurolib/optimize/exploration/exploration.py
@@ -132,14 +132,14 @@ class BoxSearch:
             self._addParametersToPypet(self.traj, self.parameterSpace.getRandom(safe=True))
 
         # Tell pypet which parameters to explore
-        self.pypetParametrization = pypet.cartesian_product(self.exploreParameters)
+        self.pypetParametrization = self.parameterSpace.get_parametrization()
         # explicitely add all parameters within star notation, hence unwrap star notation into actual params names
         if self.parameterSpace.star:
             assert self.model is not None, "With star notation, model cannot be None"
             self.pypetParametrization = unwrap_star_dotdict(self.pypetParametrization, self.model)
         self.nRuns = len(self.pypetParametrization[list(self.pypetParametrization.keys())[0]])
         logging.info(f"Number of parameter configurations: {self.nRuns}")
-
+        # TODO need to figure out how to process None.. pypet doesn't do None
         self.traj.f_explore(self.pypetParametrization)
 
         # initialization done
@@ -281,6 +281,8 @@ class BoxSearch:
         """
         model = self.model
         runParams = self.getParametersFromTraj(traj)
+        # removes keys with None values
+        # runParams = {k: v for k, v in runParams.items() if v is not None}
         if self.parameterSpace.star:
             runParams = flatten_nested_dict(flat_dict_to_nested(runParams)["parameters"])
 
@@ -497,7 +499,7 @@ class BoxSearch:
         # create intrisinsic dims for one run
         timeDictKey, run_coords = self._getCoordsFromRun(self.results[0], bold=bold)
         dataarrays = []
-        orig_search_coords = pypet.cartesian_product(self.exploreParameters)
+        orig_search_coords = self.parameterSpace.get_parametrization()
         for runId, run_result in self.results.items():
             # take exploration coordinates for this run
             expl_coords = {k: v[runId] for k, v in orig_search_coords.items()}

--- a/tests/test_exploration.py
+++ b/tests/test_exploration.py
@@ -8,8 +8,8 @@ import unittest
 import neurolib.utils.paths as paths
 import neurolib.utils.pypetUtils as pu
 import numpy as np
+import pytest
 import xarray as xr
-
 from neurolib.models.aln import ALNModel
 from neurolib.models.fhn import FHNModel
 from neurolib.models.multimodel import MultiModel
@@ -182,6 +182,36 @@ class TestExplorationMultiModel(unittest.TestCase):
         fhn_net = FitzHughNagumoNetwork(np.random.rand(2, 2), np.array([[0.0, DELAY], [DELAY, 0.0]]))
         model = MultiModel(fhn_net)
         parameters = ParameterSpace({"*input*sigma": [0.0, 0.05], "*epsilon*": [0.5, 0.6]}, allow_star_notation=True)
+        search = BoxSearch(model, parameters, filename="test_multimodel.hdf")
+        search.run()
+        search.loadResults()
+        dataarray = search.xr()
+        self.assertTrue(isinstance(dataarray, xr.DataArray))
+        self.assertTrue(isinstance(dataarray.attrs, dict))
+        self.assertListEqual(
+            list(dataarray.attrs.keys()),
+            [k.replace("*", "_").replace(".", "_").replace("|", "_") for k in parameters.dict().keys()],
+        )
+
+        end = time.time()
+        logging.info("\t > Done in {:.2f} s".format(end - start))
+
+
+@pytest.mark.skip("not ready")
+class TestExplorationMultiModelSequential(unittest.TestCase):
+    """
+    MultiModel exploration test - uses FHN network.
+    """
+
+    def test_multimodel_explore(self):
+        start = time.time()
+
+        DELAY = 13.0
+        fhn_net = FitzHughNagumoNetwork(np.random.rand(2, 2), np.array([[0.0, DELAY], [DELAY, 0.0]]))
+        model = MultiModel(fhn_net)
+        parameters = ParameterSpace(
+            {"*input*sigma": [0.0, 0.05], "*epsilon*": [0.5, 0.6, 0.7]}, allow_star_notation=True, kind="sequence"
+        )
         search = BoxSearch(model, parameters, filename="test_multimodel.hdf")
         search.run()
         search.loadResults()

--- a/tests/test_exploration.py
+++ b/tests/test_exploration.py
@@ -25,6 +25,35 @@ def randomString(stringLength=10):
     return "".join(random.choice(letters) for i in range(stringLength))
 
 
+class TestBoxSearch(unittest.TestCase):
+    """
+    Basic tests.
+    """
+
+    def test_assertions(self):
+        parameters = ParameterSpace(
+            {"mue_ext_mean": np.linspace(0, 3, 2), "mui_ext_mean": np.linspace(0, 3, 2)}, kind="sequence"
+        )
+        with pytest.raises(AssertionError):
+            _ = BoxSearch(model=None, parameterSpace=parameters)
+
+        with pytest.raises(AssertionError):
+            _ = BoxSearch(model=None, parameterSpace=None)
+
+        with pytest.raises(AssertionError):
+            _ = BoxSearch(model=None, parameterSpace=parameters, evalFunction=None)
+
+    def test_fillin_default_parameters_for_sequential(self):
+        in_dict = {"a": [None, None, 1, 2], "b": [4, 5, None, None]}
+        SHOULD_BE = {"a": [0, 0, 1, 2], "b": [4, 5, 12, 12]}
+        model_params = {"a": 0, "b": 12}
+
+        parameters = ParameterSpace({"mue_ext_mean": [1.0, 2.0]})
+        search = BoxSearch(model=ALNModel(), parameterSpace=parameters)
+        out_dict = search._fillin_default_parameters_for_sequential(in_dict, model_params)
+        self.assertDictEqual(out_dict, SHOULD_BE)
+
+
 class TestExplorationSingleNode(unittest.TestCase):
     """
     ALN single node exploration.
@@ -197,10 +226,9 @@ class TestExplorationMultiModel(unittest.TestCase):
         logging.info("\t > Done in {:.2f} s".format(end - start))
 
 
-@pytest.mark.skip("not ready")
 class TestExplorationMultiModelSequential(unittest.TestCase):
     """
-    MultiModel exploration test - uses FHN network.
+    MultiModel exploration test with sequential exploration - uses FHN network.
     """
 
     def test_multimodel_explore(self):
@@ -217,11 +245,41 @@ class TestExplorationMultiModelSequential(unittest.TestCase):
         search.loadResults()
         dataarray = search.xr()
         self.assertTrue(isinstance(dataarray, xr.DataArray))
+        self.assertTrue("run_no" in dataarray.dims)
+        self.assertEqual(len(dataarray["run_no"]), 5)
         self.assertTrue(isinstance(dataarray.attrs, dict))
         self.assertListEqual(
             list(dataarray.attrs.keys()),
             [k.replace("*", "_").replace(".", "_").replace("|", "_") for k in parameters.dict().keys()],
         )
+
+        end = time.time()
+        logging.info("\t > Done in {:.2f} s".format(end - start))
+
+
+class TestExplorationSingleNodeSequential(unittest.TestCase):
+    """
+    ALN single node test with sequential exploration.
+    """
+
+    def test_single_node(self):
+        start = time.time()
+
+        model = ALNModel()
+        parameters = ParameterSpace({"mue_ext_mean": [0.0, 1.5, 3.0], "mui_ext_mean": [1.5, 3.0]}, kind="sequence")
+        search = BoxSearch(model, parameters, filename="test_single_nodes.hdf")
+        search.run()
+        search.loadResults()
+        dataarray = search.xr()
+        self.assertTrue(isinstance(dataarray, xr.DataArray))
+        self.assertTrue("run_no" in dataarray.dims)
+        self.assertEqual(len(dataarray["run_no"]), 5)
+        self.assertFalse(dataarray.attrs)
+
+        for i in search.dfResults.index:
+            search.dfResults.loc[i, "max_r"] = np.max(
+                search.results[i]["rates_exc"][:, -int(1000 / model.params["dt"]) :]
+            )
 
         end = time.time()
         logging.info("\t > Done in {:.2f} s".format(end - start))

--- a/tests/test_parameterspace.py
+++ b/tests/test_parameterspace.py
@@ -18,14 +18,45 @@ class TestParameterSpace(unittest.TestCase):
         # 'point'
         par = ParameterSpace(["a", "b"], [[10], [3.0]])
         self.assertEqual(par.kind, "point")
+        parametrization = par.get_parametrization()
+        self.assertTrue(all(len(lst) == 1 for lst in parametrization.values()))
 
         # 'bound'
         par = ParameterSpace(["a", "b"], [[3.0, 5.0], [0.0, 3.0]])
         self.assertEqual(par.kind, "bound")
+        parametrization = par.get_parametrization()
+        self.assertTrue(all(len(lst) == 2 for lst in parametrization.values()))
 
         # 'grid'
         par = ParameterSpace(["a", "b"], [[3.0, 3.5, 5.0], [0.0, 3.0]])
         self.assertEqual(par.kind, "grid")
+        parametrization = par.get_parametrization()
+        self.assertTrue(all(len(lst) == 6 for lst in parametrization.values()))
+
+        # 'sequence'
+        par = ParameterSpace(["a", "b"], [[3.0, 3.5, 5.0], [0.0, 3.0]], kind="sequence")
+        self.assertEqual(par.kind, "sequence")
+        parametrization = par.get_parametrization()
+        self.assertTrue(all(len(lst) == 5 for lst in parametrization.values()))
+
+        # `explicit`
+        par = ParameterSpace(["a", "b"], [[3.0, 3.5, 12.5], [0.0, 3.0, 17.2]], kind="explicit")
+        self.assertEqual(par.kind, "explicit")
+        parametrization = par.get_parametrization()
+        self.assertTrue(all(len(lst) == 3 for lst in parametrization.values()))
+
+    def test_inflate_to_sequence(self):
+        SHOULD_BE = {
+            "a": [1, 2, None, None, None, None, None],
+            "b": [None, None, 3, 4, 5, None, None],
+            "c": [None, None, None, None, None, 12.0, 54.0],
+        }
+        par = ParameterSpace([], [])
+        param_dict = {"a": [1, 2], "b": [3, 4, 5], "c": [12.0, 54.0]}
+
+        result = par._inflate_to_sequence(param_dict)
+        self.assertTrue(all(len(lst) == 7 for lst in result.values()))
+        self.assertDictEqual(result, SHOULD_BE)
 
     def test_parameterspace_attributes(self):
         par = ParameterSpace(["a", "b"], [[10, 8], [3.0]])


### PR DESCRIPTION
* `sequence`: explore in a sequence instead of a grid, always changes a single parameter
* `explicit`: explicitly define an exploration space by yourself (i.e. dict with parameter names as keys and lists of the same length as values)
* some stuff around this