### PR TITLE
Minor fixes: setting seed + avoiding index out of bounds for noise array

### DIFF
--- a/neurolib/models/thalamus/model.py
+++ b/neurolib/models/thalamus/model.py
@@ -6,7 +6,7 @@ from . import timeIntegration as ti
 class ThalamicMassModel(Model):
     """
     Two population thalamic model
-    
+
     Reference:
     Costa, M. S., Weigenand, A., Ngo, H. V. V., Marshall, L., Born, J.,
     Martinetz, T., & Claussen, J. C. (2016). A thalamocortical neural mass
@@ -69,7 +69,7 @@ class ThalamicMassModel(Model):
 
         # load default parameters if none were given
         if params is None:
-            params = dp.loadDefaultParams()
+            params = dp.loadDefaultParams(seed=seed)
 
         # Initialize base class Model
         super().__init__(integration=integration, params=params)

--- a/neurolib/models/thalamus/timeIntegration.py
+++ b/neurolib/models/thalamus/timeIntegration.py
@@ -13,7 +13,7 @@ def timeIntegration(params):
 
     dt = params["dt"]  # Time step for the Euler intergration (ms)
     sqrt_dt = np.sqrt(dt)
-    duration = params["duration"]  # imulation duration (ms)
+    duration = params["duration"]  # Simulation duration (ms)
     RNGseed = params["seed"]  # seed for RNG
 
     startind = 1  # int(max_global_delay + 1)
@@ -334,7 +334,7 @@ def timeIntegration_njit_elementwise(
         s_er = s_er + dt * d_s_er
         s_gr = s_gr + dt * d_s_gr
         # noisy variable
-        ds_et = ds_et + dt * d_ds_et + gamma_e ** 2 * d_phi * sqrt_dt * noise[i]
+        ds_et = ds_et + dt * d_ds_et + gamma_e ** 2 * d_phi * sqrt_dt * noise[i - startind]
         ds_gt = ds_gt + dt * d_ds_gt
         ds_er = ds_er + dt * d_ds_er
         ds_gr = ds_gr + dt * d_ds_gr


### PR DESCRIPTION
Two minor things I encountered when working on my thalamus-aln implementation.

**Seed not set**
Seed given as argument was not set if the constructor called `loadDefaultParams()`
```python
# Before fix:
model = ThalamicMassModel(seed=42)
print(model.params["seed"])  # --> None
```

**Index out of bounds in `noise`**
`noise` has the size `len(t)` whilst `i` goes over `range(startind, startind + len(t))`.

