### PR TITLE
Fix tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies 🛠
         run: |
-          python -m pip install --upgrade pip
-          pip install flake8 codecov pytest-cov wheel setuptools matplotlib seaborn mne
+          python -m pip install --upgrade pip setuptools
+          pip install flake8 codecov pytest-cov wheel matplotlib seaborn mne
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           pip install .
       - name: Lint with flake8 🎓

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -24,7 +24,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install treon wheel setuptools jupyterlab matplotlib seaborn
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip uninstall importlib-metadata
+          pip uninstall -y importlib-metadata
           pip install "importlib-metadata<5.0"
           pip install .
       - name: Test notebooks with treon 🧪

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -24,6 +24,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install treon wheel setuptools jupyterlab matplotlib seaborn
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip uninstall importlib-metadata
+          pip install "importlib-metadata<5.0"
           pip install .
       - name: Test notebooks with treon 🧪
         run: |

--- a/neurolib/utils/functions.py
+++ b/neurolib/utils/functions.py
@@ -309,7 +309,7 @@ def getPowerSpectrum(activity, dt, maxfr=70, spectrum_windowsize=1.0, normalize=
     f, Pxx_spec = scipy.signal.welch(
         activity,
         1000 / dt,
-        window="hanning",
+        window="hann",
         nperseg=int(spectrum_windowsize * 1000 / dt),
         scaling="spectrum",
     )

--- a/neurolib/utils/signal.py
+++ b/neurolib/utils/signal.py
@@ -95,7 +95,7 @@ class Signal:
         if not filename.endswith(NC_EXT):
             filename += NC_EXT
         # load NC file
-        xarray = xr.load_dataarray(filename)
+        xarray = xr.load_dataarray(filename, engine="netcdf4")
         # init class
         signal = cls(xarray)
         # if nc file has attributes, copy them to signal class

--- a/neurolib/utils/signal.py
+++ b/neurolib/utils/signal.py
@@ -95,7 +95,7 @@ class Signal:
         if not filename.endswith(NC_EXT):
             filename += NC_EXT
         # load NC file
-        xarray = xr.load_dataarray(filename, engine="netcdf4")
+        xarray = xr.load_dataarray(filename)
         # init class
         signal = cls(xarray)
         # if nc file has attributes, copy them to signal class


### PR DESCRIPTION
The title says it all.
Anyway, @caglorithm, we should discuss maybe dropping support for lower python than 3.8.. The thing is, `xarray` did drop the support for 3.7 (and obviously for 3.6) some time ago (https://github.com/pydata/xarray/issues/7149#issuecomment-1272537456), so now loading .nc files (in `Signal` class, as done in example-3) requires hacky workaround - we need to downgrade `importlib-metadata` (dependency of `xarray`)...
The problem, of course, is that due to `pypet`, only python 3.6 and 3.7 work on macOS... so dropping support for 3.6 and 3.7 would mean dropping support for macOS :/ Or, getting rid of `pypet`...
But for now, tests should work...

@lenasal after this is merged, please rebase your PR onto the new master; then it should work for you:)