### PR TITLE
fixed bug in fhn, hopf, wc, ww models: copy params

### DIFF
--- a/neurolib/models/fhn/timeIntegration.py
+++ b/neurolib/models/fhn/timeIntegration.py
@@ -7,7 +7,7 @@ from ...utils import model_utils as mu
 
 def timeIntegration(params):
     """Sets up the parameters for time integration
-    
+
     :param params: Parameter dictionary of the model
     :type params: dict
     :return: Integrated activity variables of the model
@@ -80,8 +80,8 @@ def timeIntegration(params):
     max_global_delay = np.max(Dmat_ndt)
     startind = int(max_global_delay + 1)  # timestep to start integration at
 
-    x_ou = params["x_ou"]
-    y_ou = params["y_ou"]
+    x_ou = params["x_ou"].copy()
+    y_ou = params["y_ou"].copy()
 
     # state variable arrays, have length of t + startind
     # they store initial conditions AND simulated data
@@ -229,13 +229,13 @@ def timeIntegration_njit_elementwise(
                 - ys[no, i - 1]
                 + xs_input_d[no]  # input from other nodes
                 + x_ou[no]  # ou noise
-                + x_ext[no, i-1] # external input
+                + x_ext[no, i - 1]  # external input
             )
             y_rhs = (
                 (xs[no, i - 1] - delta - epsilon * ys[no, i - 1]) / tau
                 + ys_input_d[no]  # input from other nodes
                 + y_ou[no]  # ou noise
-                + y_ext[no, i-1] # external input
+                + y_ext[no, i - 1]  # external input
             )
 
             # Euler integration

--- a/neurolib/models/hopf/timeIntegration.py
+++ b/neurolib/models/hopf/timeIntegration.py
@@ -7,7 +7,7 @@ from ...utils import model_utils as mu
 
 def timeIntegration(params):
     """Sets up the parameters for time integration
-    
+
     :param params: Parameter dictionary of the model
     :type params: dict
     :return: Integrated activity variables of the model
@@ -74,8 +74,8 @@ def timeIntegration(params):
     max_global_delay = np.max(Dmat_ndt)
     startind = int(max_global_delay + 1)  # timestep to start integration at
 
-    x_ou = params["x_ou"]
-    y_ou = params["y_ou"]
+    x_ou = params["x_ou"].copy()
+    y_ou = params["y_ou"].copy()
 
     # state variable arrays, have length of t + startind
     # they store initial conditions AND simulated data
@@ -208,14 +208,14 @@ def timeIntegration_njit_elementwise(
                 - w * ys[no, i - 1]
                 + xs_input_d[no]  # input from other nodes
                 + x_ou[no]  # ou noise
-                + x_ext[no, i-1]  # external input
+                + x_ext[no, i - 1]  # external input
             )
             y_rhs = (
                 (a - xs[no, i - 1] ** 2 - ys[no, i - 1] ** 2) * ys[no, i - 1]
                 + w * xs[no, i - 1]
                 + ys_input_d[no]  # input from other nodes
                 + y_ou[no]  # ou noise
-                + y_ext[no, i-1]  # external input
+                + y_ext[no, i - 1]  # external input
             )
 
             # Euler integration

--- a/neurolib/models/wc/timeIntegration.py
+++ b/neurolib/models/wc/timeIntegration.py
@@ -74,8 +74,8 @@ def timeIntegration(params):
     startind = int(max_global_delay + 1)  # timestep to start integration at
 
     # noise variable
-    exc_ou = params["exc_ou"]
-    inh_ou = params["inh_ou"]
+    exc_ou = params["exc_ou"].copy()
+    inh_ou = params["inh_ou"].copy()
 
     # state variable arrays, have length of t + startind
     # they store initial conditions AND simulated data
@@ -219,7 +219,7 @@ def timeIntegration_njit_elementwise(
                         c_excexc * excs[no, i - 1]  # input from within the excitatory population
                         - c_inhexc * inhs[no, i - 1]  # input from the inhibitory population
                         + exc_input_d[no]  # input from other nodes
-                        + exc_ext[no, i-1]
+                        + exc_ext[no, i - 1]
                     )  # external input
                     + exc_ou[no]  # ou noise
                 )
@@ -233,7 +233,7 @@ def timeIntegration_njit_elementwise(
                     * S_I(
                         c_excinh * excs[no, i - 1]  # input from the excitatory population
                         - c_inhinh * inhs[no, i - 1]  # input from within the inhibitory population
-                        + inh_ext[no, i-1]
+                        + inh_ext[no, i - 1]
                     )  # external input
                     + inh_ou[no]  # ou noise
                 )

--- a/neurolib/models/ww/timeIntegration.py
+++ b/neurolib/models/ww/timeIntegration.py
@@ -91,8 +91,8 @@ def timeIntegration(params):
     startind = int(max_global_delay + 1)  # timestep to start integration at
 
     # noise variable
-    exc_ou = params["exc_ou"]
-    inh_ou = params["inh_ou"]
+    exc_ou = params["exc_ou"].copy()
+    inh_ou = params["inh_ou"].copy()
 
     # state variable arrays, have length of t + startind
     # they store initial conditions AND simulated data


### PR DESCRIPTION
x_ou, y_ou and exc_ou, inh_ou variables overwrite corresponding params, include ".copy()" to fix this