### PR TITLE
removed Dmat_ndt as param set in timeIntegration file

### DIFF
--- a/neurolib/models/fhn/timeIntegration.py
+++ b/neurolib/models/fhn/timeIntegration.py
@@ -7,7 +7,7 @@ from ...utils import model_utils as mu
 
 def timeIntegration(params):
     """Sets up the parameters for time integration
-    
+
     :param params: Parameter dictionary of the model
     :type params: dict
     :return: Integrated activity variables of the model
@@ -57,7 +57,6 @@ def timeIntegration(params):
         # no self-feedback delay
         Dmat[np.eye(len(Dmat)) == 1] = np.zeros(len(Dmat))
     Dmat_ndt = np.around(Dmat / dt).astype(int)  # delay matrix in multiples of dt
-    params["Dmat_ndt"] = Dmat_ndt
 
     # Additive or diffusive coupling scheme
     coupling = params["coupling"]
@@ -229,13 +228,13 @@ def timeIntegration_njit_elementwise(
                 - ys[no, i - 1]
                 + xs_input_d[no]  # input from other nodes
                 + x_ou[no]  # ou noise
-                + x_ext[no, i-1] # external input
+                + x_ext[no, i - 1]  # external input
             )
             y_rhs = (
                 (xs[no, i - 1] - delta - epsilon * ys[no, i - 1]) / tau
                 + ys_input_d[no]  # input from other nodes
                 + y_ou[no]  # ou noise
-                + y_ext[no, i-1] # external input
+                + y_ext[no, i - 1]  # external input
             )
 
             # Euler integration

--- a/neurolib/models/hopf/timeIntegration.py
+++ b/neurolib/models/hopf/timeIntegration.py
@@ -7,7 +7,7 @@ from ...utils import model_utils as mu
 
 def timeIntegration(params):
     """Sets up the parameters for time integration
-    
+
     :param params: Parameter dictionary of the model
     :type params: dict
     :return: Integrated activity variables of the model
@@ -62,7 +62,6 @@ def timeIntegration(params):
         Dmat = dp.computeDelayMatrix(lengthMat, signalV)
         Dmat[np.eye(len(Dmat)) == 1] = np.zeros(len(Dmat))
     Dmat_ndt = np.around(Dmat / dt).astype(int)  # delay matrix in multiples of dt
-    params["Dmat_ndt"] = Dmat_ndt
     # ------------------------------------------------------------------------
 
     # Initialization
@@ -208,14 +207,14 @@ def timeIntegration_njit_elementwise(
                 - w * ys[no, i - 1]
                 + xs_input_d[no]  # input from other nodes
                 + x_ou[no]  # ou noise
-                + x_ext[no, i-1]  # external input
+                + x_ext[no, i - 1]  # external input
             )
             y_rhs = (
                 (a - xs[no, i - 1] ** 2 - ys[no, i - 1] ** 2) * ys[no, i - 1]
                 + w * xs[no, i - 1]
                 + ys_input_d[no]  # input from other nodes
                 + y_ou[no]  # ou noise
-                + y_ext[no, i-1]  # external input
+                + y_ext[no, i - 1]  # external input
             )
 
             # Euler integration

--- a/neurolib/models/wc/timeIntegration.py
+++ b/neurolib/models/wc/timeIntegration.py
@@ -62,7 +62,6 @@ def timeIntegration(params):
         Dmat = dp.computeDelayMatrix(lengthMat, signalV)
         Dmat[np.eye(len(Dmat)) == 1] = np.zeros(len(Dmat))
     Dmat_ndt = np.around(Dmat / dt).astype(int)  # delay matrix in multiples of dt
-    params["Dmat_ndt"] = Dmat_ndt
     # ------------------------------------------------------------------------
     # Initialization
     # Floating point issue in np.arange() workaraound: use integers in np.arange()
@@ -219,7 +218,7 @@ def timeIntegration_njit_elementwise(
                         c_excexc * excs[no, i - 1]  # input from within the excitatory population
                         - c_inhexc * inhs[no, i - 1]  # input from the inhibitory population
                         + exc_input_d[no]  # input from other nodes
-                        + exc_ext[no, i-1]
+                        + exc_ext[no, i - 1]
                     )  # external input
                     + exc_ou[no]  # ou noise
                 )
@@ -233,7 +232,7 @@ def timeIntegration_njit_elementwise(
                     * S_I(
                         c_excinh * excs[no, i - 1]  # input from the excitatory population
                         - c_inhinh * inhs[no, i - 1]  # input from within the inhibitory population
-                        + inh_ext[no, i-1]
+                        + inh_ext[no, i - 1]
                     )  # external input
                     + inh_ou[no]  # ou noise
                 )

--- a/neurolib/models/ww/timeIntegration.py
+++ b/neurolib/models/ww/timeIntegration.py
@@ -67,7 +67,6 @@ def timeIntegration(params):
         # no self-feedback delay
         Dmat[np.eye(len(Dmat)) == 1] = np.zeros(len(Dmat))
     Dmat_ndt = np.around(Dmat / dt).astype(int)  # delay matrix in multiples of dt
-    params["Dmat_ndt"] = Dmat_ndt
 
     # # Additive or diffusive coupling scheme
     # version = params["version"]


### PR DESCRIPTION
This PR removes `params["Dmat_ndt"] = Dmat_ndt` as a parameter from the FHN, Hopf, WC, WW models because `Dmat_ndt` is derived from `lengthMat` and is not a parameter that should be set by the user.