### PR TITLE
Bug Fix: Setting value of tau_inh in timeIntegration

### DIFF
--- a/neurolib/models/ww/timeIntegration.py
+++ b/neurolib/models/ww/timeIntegration.py
@@ -30,7 +30,7 @@ def timeIntegration(params):
     a_inh = params["a_inh"]
     b_inh = params["b_inh"]
     d_inh = params["d_inh"]
-    tau_inh = params["tau_exc"]
+    tau_inh = params["tau_inh"]
     w_inh = params["w_inh"]
     inh_current_baseline = params["inh_current_baseline"]
 


### PR DESCRIPTION
Hello, I observed a discrepancy in analysis using models.ww when compared to analysis from another implementation. Further experimentation led me to notice the steady state values were different from the analytical solution (in the non-stochastic case). Luckily, I was able to identify the source of the issue, which was simply setting tau_inh incorrectly in models.ww.timeIntegration. Hopefully this can be merged quickly. Thank you!