### PR TITLE
fix: replace bare except blocks, deprecated logging.warn, dead code, and mutable default

### DIFF
--- a/neurolib/models/model.py
+++ b/neurolib/models/model.py
@@ -75,13 +75,13 @@ class Model:
         Adds the simulated BOLD signal to outputs.
         """
         if not self.boldInitialized:
-            logging.warn("BOLD model not initialized, not simulating BOLD. Use `run(bold=True)`")
+            logging.warning("BOLD model not initialized, not simulating BOLD. Use `run(bold=True)`")
             return
 
         bold_input = bold_variable[:, self.startindt :]
         # logging.debug(f"BOLD input `{svn}` of shape {bold_input.shape}")
         if not bold_input.shape[1] >= self.boldModel.samplingRate_NDt:
-            logging.warn(
+            logging.warning(
                 f"Will not simulate BOLD if output {bold_input.shape[1]*self.params['dt']} not at least of duration {self.boldModel.samplingRate_NDt*self.params['dt']}"
             )
             return
@@ -91,7 +91,7 @@ class Model:
         # so: we are lazy here and simply disable appending in that case ...
         if append and not bold_input.shape[1] % self.boldModel.samplingRate_NDt == 0:
             append = False
-            logging.warn(
+            logging.warning(
                 f"Output size {bold_input.shape[1]} is not a multiple of BOLD sampling length { self.boldModel.samplingRate_NDt}, will not append data."
             )
         logging.debug(f"Simulating BOLD: boldModel.run()")

--- a/neurolib/optimize/evolution/evolutionaryUtils.py
+++ b/neurolib/optimize/evolution/evolutionaryUtils.py
@@ -49,8 +49,8 @@ def saveToPypet(traj, pop, gIdx):
                 unpackOutputsAndStore(p.outputs, save_string=f"outputs.ind_{p.id:06d}")
 
         traj.f_store()
-    except:
-        logging.warn("Error: Write to pypet failed!")
+    except Exception:
+        logging.warning("Error: Write to pypet failed!")
     return pop
 
 

--- a/neurolib/utils/functions.py
+++ b/neurolib/utils/functions.py
@@ -161,7 +161,7 @@ def fcd(ts, windowsize=30, stepsize=5):
             f1i += 1
 
         return FCd
-    except:
+    except Exception:
         return 0
 
 

--- a/neurolib/utils/loadData.py
+++ b/neurolib/utils/loadData.py
@@ -177,7 +177,7 @@ class Dataset:
         name,
         apply="single",
         apply_function=None,
-        apply_function_kwargs={},
+        apply_function_kwargs=None,
         normalizeCmats="max",
     ):
         """Load data of a certain kind for all users of the current dataset
@@ -193,6 +193,8 @@ class Dataset:
         :return: Subjectwise data, after function apply
         :rtype: list[np.ndarray]
         """
+        if apply_function_kwargs is None:
+            apply_function_kwargs = {}
         values = []
         for subject, value in self.data["subjects"].items():
             assert name in value, f"Data type {name} not found in dataset of subject {subject}."
@@ -317,7 +319,6 @@ class Dataset:
         elif type(matrix) is dict:
             raise ValueError(f"Object is still a dict. Here are the keys: {matrix.keys()}")
         return matrix
-        return 0
 
 
 def filterSubcortical(a, axis="both"):

--- a/neurolib/utils/pypetUtils.py
+++ b/neurolib/utils/pypetUtils.py
@@ -36,7 +36,7 @@ def loadPypetTrajectory(filename, trajectoryName):
     logging.info(f"Loading results from {filename}")
 
     # if trajectoryName is not specified, load the most recent trajectory
-    if trajectoryName == None:
+    if trajectoryName is None:
         trajectoryName = getTrajectorynamesInFile(filename)[-1]
     logging.info(f"Analyzing trajectory {trajectoryName}")
 


### PR DESCRIPTION
## Summary

- **Replace bare `except:` with `except Exception:`** in `utils/functions.py` (`fcd()`) and `optimize/evolution/evolutionaryUtils.py` (`saveToPypet()`). Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, preventing users from interrupting long-running simulations.

- **Replace deprecated `logging.warn()` with `logging.warning()`** in `models/model.py` (3 occurrences) and `evolutionaryUtils.py` (1 occurrence). `logging.warn()` has been deprecated since Python 3.3.

- **Remove unreachable dead code** `return 0` after `return matrix` in `utils/loadData.py` `loadMatrix()` method.

- **Fix mutable default argument** `apply_function_kwargs={}` → `apply_function_kwargs=None` with guard in `utils/loadData.py` `getDataPerSubject()` method.

- **Fix `== None` → `is None`** in `utils/pypetUtils.py` (PEP 8).

## Test plan

- [ ] No behavioral changes — bare except replacement preserves all Exception-derived catches
- [ ] `logging.warning()` is the non-deprecated equivalent of `logging.warn()`
- [ ] Dead `return 0` was never reachable
- [ ] Mutable default fix: `None` guard produces identical empty dict behavior